### PR TITLE
fix finding 41 - modules can prevent from uninstalling themselves

### DIFF
--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -222,7 +222,7 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
         require(success, NexusInitializationFailed());
     }
 
-    function setRegistry(IERC7484 newRegistry, address[] calldata attesters, uint8 threshold) external onlyEntryPointOrSelf {
+    function setRegistry(IERC7484 newRegistry, address[] calldata attesters, uint8 threshold) external payable onlyEntryPointOrSelf {
         _configureRegistry(newRegistry, attesters, threshold);
     }
 

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -225,7 +225,6 @@ abstract contract ModuleManager is Storage, Receiver, EIP712, IModuleManagerEven
 
         validators.pop(prev, validator);
         (bool success, ) = validator.call(abi.encodeWithSelector(IModule.onUninstall.selector, disableModuleData));
-        if(!success) return;
     }
 
     /// @dev Installs a new executor module after checking if it matches the required module type.
@@ -244,7 +243,6 @@ abstract contract ModuleManager is Storage, Receiver, EIP712, IModuleManagerEven
         (address prev, bytes memory disableModuleData) = abi.decode(data, (address, bytes));
         _getAccountStorage().executors.pop(prev, executor);
         (bool success, ) = executor.call(abi.encodeWithSelector(IModule.onUninstall.selector, disableModuleData));
-        if(!success) return;
     }
 
     /// @dev Installs a hook module, ensuring no other hooks are installed before proceeding.
@@ -264,7 +262,6 @@ abstract contract ModuleManager is Storage, Receiver, EIP712, IModuleManagerEven
     function _uninstallHook(address hook, bytes calldata data) internal virtual {
         _setHook(address(0));
         (bool success, ) = hook.call(abi.encodeWithSelector(IModule.onUninstall.selector, data));
-        if(!success) return;
     }
 
     /// @dev Sets the current hook in the storage to the specified address.
@@ -314,7 +311,6 @@ abstract contract ModuleManager is Storage, Receiver, EIP712, IModuleManagerEven
     function _uninstallFallbackHandler(address fallbackHandler, bytes calldata data) internal virtual {
         _getAccountStorage().fallbacks[bytes4(data[0:4])] = FallbackHandler(address(0), CallType.wrap(0x00));
         (bool success, ) = fallbackHandler.call(abi.encodeWithSelector(IModule.onUninstall.selector, data[4:]));
-        if(!success) return;
     }
 
     /// To make it easier to install multiple modules at once, this function will

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -17,6 +17,7 @@ import { SentinelListLib } from "sentinellist/src/SentinelList.sol";
 
 import { Storage } from "./Storage.sol";
 import { IHook } from "../interfaces/modules/IHook.sol";
+import { IModule } from "../interfaces/modules/IModule.sol";
 import { IExecutor } from "../interfaces/modules/IExecutor.sol";
 import { IFallback } from "../interfaces/modules/IFallback.sol";
 import { IValidator } from "../interfaces/modules/IValidator.sol";
@@ -223,7 +224,10 @@ abstract contract ModuleManager is Storage, Receiver, EIP712, IModuleManagerEven
         require(!(prev == address(0x01) && validators.getNext(validator) == address(0x01)), CannotRemoveLastValidator());
 
         validators.pop(prev, validator);
-        IValidator(validator).onUninstall(disableModuleData);
+        try IValidator(validator).onUninstall(disableModuleData) {
+        } catch {
+           return;
+        }
     }
 
     /// @dev Installs a new executor module after checking if it matches the required module type.
@@ -241,7 +245,10 @@ abstract contract ModuleManager is Storage, Receiver, EIP712, IModuleManagerEven
     function _uninstallExecutor(address executor, bytes calldata data) internal virtual {
         (address prev, bytes memory disableModuleData) = abi.decode(data, (address, bytes));
         _getAccountStorage().executors.pop(prev, executor);
-        IExecutor(executor).onUninstall(disableModuleData);
+        try IExecutor(executor).onUninstall(disableModuleData) {
+        } catch {
+            return;
+        }
     }
 
     /// @dev Installs a hook module, ensuring no other hooks are installed before proceeding.
@@ -260,7 +267,10 @@ abstract contract ModuleManager is Storage, Receiver, EIP712, IModuleManagerEven
     /// @param data De-initialization data to configure the hook upon uninstallation.
     function _uninstallHook(address hook, bytes calldata data) internal virtual {
         _setHook(address(0));
-        IHook(hook).onUninstall(data);
+        try IHook(hook).onUninstall(data) {
+        } catch {
+            return;
+        }
     }
 
     /// @dev Sets the current hook in the storage to the specified address.
@@ -309,7 +319,10 @@ abstract contract ModuleManager is Storage, Receiver, EIP712, IModuleManagerEven
     /// @param data The de-initialization data containing the selector.
     function _uninstallFallbackHandler(address fallbackHandler, bytes calldata data) internal virtual {
         _getAccountStorage().fallbacks[bytes4(data[0:4])] = FallbackHandler(address(0), CallType.wrap(0x00));
-        IFallback(fallbackHandler).onUninstall(data[4:]);
+        try IFallback(fallbackHandler).onUninstall(data[4:]) {
+        } catch {
+            return;
+        }
     }
 
     /// To make it easier to install multiple modules at once, this function will


### PR DESCRIPTION
have used try catch

but could also have done it like this

(bool success, ) = hook.call(abi.encodeWithSelector(IModule.onUninstall.selector, data));
        if (!success) {
        // leave this block empty to ignore the revert
        }