### PR TITLE
🔒 M-01 - Prevent Replay Attacks by Enforcing Signature Malleability Check

### DIFF
--- a/test/foundry/unit/concrete/modules/TestK1Validator.tree
+++ b/test/foundry/unit/concrete/modules/TestK1Validator.tree
@@ -14,6 +14,12 @@ TestK1Validator
 ├── when testing the isValidSignatureWithSender function
 │   ├── it should succeed with a valid signature
 │   └── it should fail with an invalid signature
+│   └── it should succeed with a valid signature for isValidSignatureWithSender
+│   └── it should fail with an invalid 's' value for isValidSignatureWithSender
+├── when testing the transferOwnership function
+│   ├── it should transfer ownership to a new address
+│   └── it should revert when transferring to the zero address
+│   └── it should revert when transferring to a contract address
 ├── when testing the name function
 │   └── it should return the correct contract name
 ├── when testing the version function


### PR DESCRIPTION
#### M-01. Potential Replay Attack Vulnerability in Signature Verification Logic

- **Issue**: Signature malleability due to lack of checks on the `s` value.
- **Affected Functions**: Signature verification logic.
- **Fix**: Add check to ensure `s` value is greater than `0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0`.
