### PR TITLE
🔒 M-06 - Correct Typehash for ModuleEnableMode Struct to Meet EIP-712 Standards

### DIFF
--- a/contracts/types/Constants.sol
+++ b/contracts/types/Constants.sol
@@ -38,7 +38,12 @@ uint256 constant MODULE_TYPE_FALLBACK = 3;
 
 // Module type identifier for hooks
 uint256 constant MODULE_TYPE_HOOK = 4;
-bytes32 constant MODULE_ENABLE_MODE_TYPE_HASH = keccak256("ModuleEnableMode(address module, bytes32 initDataHash)");
 
+// Typehash for ModuleEnableMode struct, compliant with EIP-712
+bytes32 constant MODULE_ENABLE_MODE_TYPE_HASH = keccak256("ModuleEnableMode(address module,bytes initData)");
+
+// Mode for validation
 bytes1 constant MODE_VALIDATION = 0x00;
+
+// Mode for module enablement
 bytes1 constant MODE_MODULE_ENABLE = 0x01;


### PR DESCRIPTION
#### M-06. Typehash for ModuleEnableMode struct is incorrect

- **Issue**: Incorrect typehash for the `ModuleEnableMode` structure.
- **Affected Functions**: `_getEnableModeDataHash`.
- **Fix**: Correct the typehash to `keccak256("ModuleEnableMode(address module,bytes initData)")`.

---