### PR TITLE
🔒 L-01 & L-02 - Prevent Data Loss in Events and Allow Overriding of entryPoint() Function

### DIFF
--- a/contracts/base/BaseAccount.sol
+++ b/contracts/base/BaseAccount.sol
@@ -121,7 +121,7 @@ contract BaseAccount is Storage, IBaseAccount {
     /// @dev This function returns the address of the canonical ERC4337 EntryPoint contract.
     /// It can be overridden to return a different EntryPoint address if needed.
     /// @return The address of the EntryPoint contract.
-    function entryPoint() external view returns (address) {
+    function entryPoint() external view virtual returns (address) {
         return _ENTRYPOINT;
     }
 }

--- a/contracts/interfaces/factory/INexusFactory.sol
+++ b/contracts/interfaces/factory/INexusFactory.sol
@@ -24,7 +24,7 @@ interface INexusFactory {
     /// @param account The address of the newly created account.
     /// @param initData Initialization data used for the new Smart Account.
     /// @param salt Unique salt used during the creation of the Smart Account.
-    event AccountCreated(address indexed account, bytes indexed initData, bytes32 indexed salt);
+    event AccountCreated(address indexed account, bytes initData, bytes32 indexed salt);
 
     /// @notice Error indicating that the account is already deployed
     /// @param account The address of the account that is already deployed

--- a/test/foundry/utils/EventsAndErrors.sol
+++ b/test/foundry/utils/EventsAndErrors.sol
@@ -7,7 +7,7 @@ contract EventsAndErrors {
     // ==========================
     // Events
     // ==========================
-    event AccountCreated(address indexed account, bytes indexed initData, bytes32 indexed salt);
+    event AccountCreated(address indexed account, bytes initData, bytes32 indexed salt);
     event GenericFallbackCalled(address sender, uint256 value, bytes data);
     event Deposited(address indexed account, uint256 totalDeposit);
     event ModuleInstalled(uint256 moduleTypeId, address module);


### PR DESCRIPTION
#### L-01. The `indexed` Keyword in Events Causes Data Loss for Variables of type `bytes`

- **Issue**: `indexed` keyword causes data loss for `bytes` variables in events.
- **Affected Events**: `AccountCreated` in `NexusAccountFactory`.
- **Fix**: Remove `indexed` keyword from `bytes` variables in events.

---

#### L-02. entryPoint() function cannot be overridden

- **Issue**: `entryPoint()` function lacks the `virtual` keyword.
- **Affected Functions**: `entryPoint`.
- **Fix**: Add `virtual` keyword to `entryPoint()` function.

---