### PR TITLE
Fix Finding #19: Ensure Validator Module Type Check in Enable Mode

### DIFF
--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -107,8 +107,10 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
         } else {
             PackedUserOperation memory userOp = op;
             userOp.signature = _enableMode(validator, op.signature);
+            // Ensure the module being enabled is a validator
+            if (!_isValidatorInstalled(validator)) return VALIDATION_FAILED;
             validationData = IValidator(validator).validateUserOp(userOp, userOpHash);
-        }    
+        }
     }
 
     /// @notice Executes transactions in single or batch modes as specified by the execution mode.

--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -147,7 +147,7 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
         } else if (callType == CALLTYPE_BATCH) {
             returnData = _handleBatchExecutionAndReturnData(executionCalldata, execType);
         } else if (callType == CALLTYPE_DELEGATECALL) {
-            returnData =  _handleDelegateCallExecutionAndReturnData(executionCalldata, execType);
+            returnData = _handleDelegateCallExecutionAndReturnData(executionCalldata, execType);
         } else {
             revert UnsupportedCallType(callType);
         }

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -158,17 +158,18 @@ abstract contract ModuleManager is Storage, Receiver, EIP712, IModuleManagerEven
     /// @param module The address of the module to be installed.
     /// @param packedData Data source to parse data required to perform Module Enable mode from.
     /// @return userOpSignature the clean signature which can be further used for userOp validation
-    function _enableMode(address module, bytes calldata packedData) internal returns (bytes calldata userOpSignature) {   
+    function _enableMode(address module, bytes calldata packedData) internal returns (bytes calldata userOpSignature) {
         uint256 moduleType;
         bytes calldata moduleInitData;
         bytes calldata enableModeSignature;
-        
-        (moduleType, moduleInitData, enableModeSignature, userOpSignature) = packedData.parseEnableModeData();  
 
-        _checkEnableModeSignature(
-            _getEnableModeDataHash(module, moduleInitData),
-            enableModeSignature
-        );
+        (moduleType, moduleInitData, enableModeSignature, userOpSignature) = packedData.parseEnableModeData();
+
+        _checkEnableModeSignature(_getEnableModeDataHash(module, moduleInitData), enableModeSignature);
+
+        // Ensure the module type is VALIDATOR or MULTI
+        if (moduleType != MODULE_TYPE_VALIDATOR && moduleType != MODULE_TYPE_MULTI) revert InvalidModule(module);
+
         _installModule(moduleType, module, moduleInitData);
     }
 

--- a/test/foundry/unit/concrete/modulemanager/TestModuleManager_EnableMode.tree
+++ b/test/foundry/unit/concrete/modulemanager/TestModuleManager_EnableMode.tree
@@ -5,5 +5,11 @@ TestModuleManager_EnableMode
 │   └── it should install the hook module
 ├── when trying to use wrong validator to validate enable mode sig
 │   └── it should revert
-└── when trying to use wrong enable mode signature
+├── when trying to use wrong enable mode signature
+│   └── it should revert
+├── when using a valid multi-module
+│   └── it should successfully install and configure the new module
+├── when using an invalid module type
+│   └── it should revert
+└── when using an invalid signature
     └── it should revert


### PR DESCRIPTION
- Ensures proper validation of module type during enable mode in `validateUserOp`.
- Adds a check to confirm the module type is a validator.
- Prevents bypassing validation by non-validator module types.