### PR TITLE
Fix/finding #21 - Emit Events for Failed Try Execution in `execute`

### DIFF
--- a/contracts/base/ExecutionHelper.sol
+++ b/contracts/base/ExecutionHelper.sol
@@ -140,8 +140,10 @@ contract ExecutionHelper is IExecutionHelperEventsAndErrors {
     function _handleSingleExecution(bytes calldata executionCalldata, ExecType execType) internal {
         (address target, uint256 value, bytes calldata callData) = executionCalldata.decodeSingle();
         if (execType == EXECTYPE_DEFAULT) _execute(target, value, callData);
-        else if (execType == EXECTYPE_TRY) _tryExecute(target, value, callData);
-        else revert UnsupportedExecType(execType);
+        else if (execType == EXECTYPE_TRY) {
+            (bool success, bytes memory result) = _tryExecute(target, value, callData);
+            if (!success) emit TryExecuteUnsuccessful(0, result);
+        } else revert UnsupportedExecType(execType);
     }
 
     /// @dev Executes a batch of transactions based on the specified execution type.
@@ -160,14 +162,16 @@ contract ExecutionHelper is IExecutionHelperEventsAndErrors {
     function _handleDelegateCallExecution(bytes calldata executionCalldata, ExecType execType) internal {
         (address delegate, bytes calldata callData) = executionCalldata.decodeDelegateCall();
         if (execType == EXECTYPE_DEFAULT) _executeDelegatecall(delegate, callData);
-        else if (execType == EXECTYPE_TRY) _tryExecuteDelegatecall(delegate, callData);
-        else revert UnsupportedExecType(execType);
+        else if (execType == EXECTYPE_TRY) {
+            (bool success, bytes memory result) = _tryExecuteDelegatecall(delegate, callData);
+            if (!success) emit TryDelegateCallUnsuccessful(0, result);
+        } else revert UnsupportedExecType(execType);
     }
 
     /// @dev Executes a single transaction based on the specified execution type.
     /// @param executionCalldata The calldata containing the transaction details (target address, value, and data).
     /// @param execType The execution type, which can be DEFAULT (revert on failure) or TRY (return on failure).
-    function _handleSingleExecutionAndReturnData(bytes calldata executionCalldata, ExecType execType) internal returns(bytes[] memory returnData) {
+    function _handleSingleExecutionAndReturnData(bytes calldata executionCalldata, ExecType execType) internal returns (bytes[] memory returnData) {
         (address target, uint256 value, bytes calldata callData) = executionCalldata.decodeSingle();
         returnData = new bytes[](1);
         bool success;
@@ -182,10 +186,10 @@ contract ExecutionHelper is IExecutionHelperEventsAndErrors {
         }
     }
 
-     /// @dev Executes a batch of transactions based on the specified execution type.
+    /// @dev Executes a batch of transactions based on the specified execution type.
     /// @param executionCalldata The calldata for a batch of transactions.
     /// @param execType The execution type, which can be DEFAULT (revert on failure) or TRY (return on failure).
-    function _handleBatchExecutionAndReturnData(bytes calldata executionCalldata, ExecType execType) internal returns(bytes[] memory returnData){
+    function _handleBatchExecutionAndReturnData(bytes calldata executionCalldata, ExecType execType) internal returns (bytes[] memory returnData) {
         Execution[] calldata executions = executionCalldata.decodeBatch();
         if (execType == EXECTYPE_DEFAULT) returnData = _executeBatch(executions);
         else if (execType == EXECTYPE_TRY) returnData = _tryExecuteBatch(executions);
@@ -195,17 +199,18 @@ contract ExecutionHelper is IExecutionHelperEventsAndErrors {
     /// @dev Executes a single transaction based on the specified execution type.
     /// @param executionCalldata The calldata containing the transaction details (target address, value, and data).
     /// @param execType The execution type, which can be DEFAULT (revert on failure) or TRY (return on failure).
-    function _handleDelegateCallExecutionAndReturnData(bytes calldata executionCalldata, ExecType execType) internal returns(bytes[] memory returnData) {
+    function _handleDelegateCallExecutionAndReturnData(
+        bytes calldata executionCalldata,
+        ExecType execType
+    ) internal returns (bytes[] memory returnData) {
         (address delegate, bytes calldata callData) = executionCalldata.decodeDelegateCall();
         returnData = new bytes[](1);
         bool success;
-        if (execType == EXECTYPE_DEFAULT) { 
+        if (execType == EXECTYPE_DEFAULT) {
             returnData[0] = _executeDelegatecall(delegate, callData);
-        }
-        else if (execType == EXECTYPE_TRY) {
+        } else if (execType == EXECTYPE_TRY) {
             (success, returnData[0]) = _tryExecuteDelegatecall(delegate, callData);
             if (!success) emit TryDelegateCallUnsuccessful(0, returnData[0]);
-        }
-        else revert UnsupportedExecType(execType);
+        } else revert UnsupportedExecType(execType);
     }
 }

--- a/contracts/base/ExecutionHelper.sol
+++ b/contracts/base/ExecutionHelper.sol
@@ -142,7 +142,7 @@ contract ExecutionHelper is IExecutionHelperEventsAndErrors {
         if (execType == EXECTYPE_DEFAULT) _execute(target, value, callData);
         else if (execType == EXECTYPE_TRY) {
             (bool success, bytes memory result) = _tryExecute(target, value, callData);
-            if (!success) emit TryExecuteUnsuccessful(0, result);
+            if (!success) emit TryExecuteUnsuccessful(callData, result);
         } else revert UnsupportedExecType(execType);
     }
 
@@ -164,7 +164,7 @@ contract ExecutionHelper is IExecutionHelperEventsAndErrors {
         if (execType == EXECTYPE_DEFAULT) _executeDelegatecall(delegate, callData);
         else if (execType == EXECTYPE_TRY) {
             (bool success, bytes memory result) = _tryExecuteDelegatecall(delegate, callData);
-            if (!success) emit TryDelegateCallUnsuccessful(0, result);
+            if (!success) emit TryDelegateCallUnsuccessful(callData, result);
         } else revert UnsupportedExecType(execType);
     }
 

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -158,17 +158,18 @@ abstract contract ModuleManager is Storage, Receiver, EIP712, IModuleManagerEven
     /// @param module The address of the module to be installed.
     /// @param packedData Data source to parse data required to perform Module Enable mode from.
     /// @return userOpSignature the clean signature which can be further used for userOp validation
-    function _enableMode(address module, bytes calldata packedData) internal returns (bytes calldata userOpSignature) {   
+    function _enableMode(address module, bytes calldata packedData) internal returns (bytes calldata userOpSignature) {
         uint256 moduleType;
         bytes calldata moduleInitData;
         bytes calldata enableModeSignature;
-        
-        (moduleType, moduleInitData, enableModeSignature, userOpSignature) = packedData.parseEnableModeData();  
 
-        _checkEnableModeSignature(
-            _getEnableModeDataHash(module, moduleInitData),
-            enableModeSignature
-        );
+        (moduleType, moduleInitData, enableModeSignature, userOpSignature) = packedData.parseEnableModeData();
+
+        _checkEnableModeSignature(_getEnableModeDataHash(module, moduleInitData), enableModeSignature);
+
+        // Ensure the module type is VALIDATOR or MULTI
+        if (moduleType != MODULE_TYPE_VALIDATOR && moduleType != MODULE_TYPE_MULTI) revert InvalidModule(module);
+
         _installModule(moduleType, module, moduleInitData);
     }
 

--- a/test/foundry/unit/concrete/accountexecution/TestAccountExecution_TryExecuteBatch.t.sol
+++ b/test/foundry/unit/concrete/accountexecution/TestAccountExecution_TryExecuteBatch.t.sol
@@ -82,7 +82,7 @@ contract TestAccountExecution_TryExecuteBatch is TestAccountExecution_Base {
         PackedUserOperation[] memory userOps = buildPackedUserOperation(BOB, BOB_ACCOUNT, EXECTYPE_TRY, executions, address(VALIDATOR_MODULE));
 
         vm.expectEmit(true, true, true, true);
-        emit TryExecuteUnsuccessful(executions[1].callData, abi.encodeWithSignature("Error(string)", "Counter: Revert operation"));
+        emit TryExecuteUnsuccessful(executions[0].callData, abi.encodeWithSignature("Error(string)", "Counter: Revert operation"));
         ENTRYPOINT.handleOps(userOps, payable(BOB.addr));
     }
 

--- a/test/foundry/unit/concrete/accountexecution/TestAccountExecution_TryExecuteSingle.t.sol
+++ b/test/foundry/unit/concrete/accountexecution/TestAccountExecution_TryExecuteSingle.t.sol
@@ -143,7 +143,7 @@ contract TestAccountExecution_TryExecuteSingle is TestAccountExecution_Base {
 
         // Expect the TryExecuteUnsuccessful event to be emitted with specific data
         vm.expectEmit(true, true, true, true);
-        emit TryExecuteUnsuccessful(0, abi.encodeWithSignature("Error(string)", "Counter: Revert operation"));
+        emit TryExecuteUnsuccessful(execution[0].callData, abi.encodeWithSignature("Error(string)", "Counter: Revert operation"));
 
         ENTRYPOINT.handleOps(userOps, payable(BOB.addr));
 

--- a/test/foundry/unit/concrete/accountexecution/TestAccountExecution_TryExecuteSingle.t.sol
+++ b/test/foundry/unit/concrete/accountexecution/TestAccountExecution_TryExecuteSingle.t.sol
@@ -130,4 +130,56 @@ contract TestAccountExecution_TryExecuteSingle is TestAccountExecution_Base {
         assertEq(token.balanceOf(ALICE.addr), transferFromAmount, "TransferFrom did not execute correctly");
         assertEq(token.allowance(address(BOB_ACCOUNT), CHARLIE.addr), approvalAmount - transferFromAmount, "Allowance not updated correctly");
     }
+
+    /// @notice Tests if the TryExecuteUnsuccessful event is emitted correctly when execution fails.
+    function test_TryExecuteSingle_EmitTryExecuteUnsuccessful() public {
+        // Initial state assertion
+        assertEq(counter.getNumber(), 0, "Counter should start at 0");
+
+        Execution[] memory execution = new Execution[](1);
+        execution[0] = Execution(address(counter), 0, abi.encodeWithSelector(Counter.revertOperation.selector));
+
+        PackedUserOperation[] memory userOps = buildPackedUserOperation(BOB, BOB_ACCOUNT, EXECTYPE_TRY, execution, address(VALIDATOR_MODULE));
+
+        // Expect the TryExecuteUnsuccessful event to be emitted with specific data
+        vm.expectEmit(true, true, true, true);
+        emit TryExecuteUnsuccessful(0, abi.encodeWithSignature("Error(string)", "Counter: Revert operation"));
+
+        ENTRYPOINT.handleOps(userOps, payable(BOB.addr));
+
+        // Asserting the counter did not increment
+        assertEq(counter.getNumber(), 0, "Counter should not have been incremented after revert");
+    }
+
+    /// @notice Tests if the TryDelegateCallUnsuccessful event is emitted correctly when delegate call execution fails.
+    function test_TryExecuteDelegateCall_EmitTryDelegateCallUnsuccessful() public {
+        // Create calldata for the account to execute a failing delegate call
+        Execution[] memory execution = new Execution[](1);
+        execution[0] = Execution(address(counter), 0, abi.encodeWithSelector(Counter.revertOperation.selector));
+
+        // Build UserOperation for delegate call execution
+        PackedUserOperation[] memory userOps = buildPackedUserOperation(BOB, BOB_ACCOUNT, EXECTYPE_TRY, execution, address(VALIDATOR_MODULE));
+
+        // Create delegate call data
+        bytes memory userOpCalldata = abi.encodeCall(
+            Nexus.execute,
+            (
+                ModeLib.encode(CALLTYPE_DELEGATECALL, EXECTYPE_TRY, MODE_DEFAULT, ModePayload.wrap(0x00)),
+                abi.encodePacked(address(counter), execution[0].callData)
+            )
+        );
+
+        userOps[0].callData = userOpCalldata;
+
+        // Sign the operation
+        bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
+        userOps[0].signature = signMessage(BOB, userOpHash);
+
+        // Expect the TryDelegateCallUnsuccessful event to be emitted
+        vm.expectEmit(true, true, true, true);
+        emit TryDelegateCallUnsuccessful(0, abi.encodeWithSignature("Error(string)", "Counter: Revert operation"));
+
+        // Execute the operation
+        ENTRYPOINT.handleOps(userOps, payable(BOB.addr));
+    }
 }

--- a/test/foundry/unit/concrete/accountexecution/TestAccountExecution_TryExecuteSingle.tree
+++ b/test/foundry/unit/concrete/accountexecution/TestAccountExecution_TryExecuteSingle.tree
@@ -10,5 +10,9 @@ TestAccountExecution_TryExecuteSingle
     │   └── it should transfer ETH correctly
     ├── when executing a token transfer in single execution
     │   └── it should transfer tokens correctly
-    └── when executing approve and transferFrom in single execution
-        └── it should update balances and allowances correctly
+    ├── when executing approve and transferFrom in single execution
+    │   └── it should update balances and allowances correctly
+    ├── when execution fails
+    │   └── it should emit the TryExecuteUnsuccessful event
+    └── when delegate call execution fails
+        └── it should emit the TryDelegateCallUnsuccessful event

--- a/test/foundry/unit/concrete/modulemanager/TestModuleManager_EnableMode.tree
+++ b/test/foundry/unit/concrete/modulemanager/TestModuleManager_EnableMode.tree
@@ -5,5 +5,11 @@ TestModuleManager_EnableMode
 │   └── it should install the hook module
 ├── when trying to use wrong validator to validate enable mode sig
 │   └── it should revert
-└── when trying to use wrong enable mode signature
+├── when trying to use wrong enable mode signature
+│   └── it should revert
+├── when using a valid multi-module
+│   └── it should successfully install and configure the new module
+├── when using an invalid module type
+│   └── it should revert
+└── when using an invalid signature
     └── it should revert

--- a/test/foundry/utils/EventsAndErrors.sol
+++ b/test/foundry/utils/EventsAndErrors.sol
@@ -16,6 +16,7 @@ contract EventsAndErrors {
     event PreCheckCalled();
     event PostCheckCalled();
     event TryExecuteUnsuccessful(uint256 batchExecutionindex, bytes result);
+    event TryDelegateCallUnsuccessful(uint256 batchExecutionindex, bytes result);
 
     // ==========================
     // General Errors

--- a/test/foundry/utils/EventsAndErrors.sol
+++ b/test/foundry/utils/EventsAndErrors.sol
@@ -16,6 +16,7 @@ contract EventsAndErrors {
     event PreCheckCalled();
     event PostCheckCalled();
     event TryExecuteUnsuccessful(bytes callData, bytes result);
+    event TryDelegateCallUnsuccessful(uint256 batchExecutionindex, bytes result);
 
     // ==========================
     // General Errors

--- a/test/hardhat/smart-account/Nexus.Basics.specs.ts
+++ b/test/hardhat/smart-account/Nexus.Basics.specs.ts
@@ -404,74 +404,74 @@ describe("Nexus Basic Specs", function () {
       expect(isValid).to.equal("0x1626ba7e");
     });
 
-    // it("Should check signature validity using smart account isValidSignature", async function () {
-    //   const isModuleInstalled = await smartAccount.isModuleInstalled(
-    //     ModuleType.Validation,
-    //     await validatorModule.getAddress(),
-    //     ethers.hexlify("0x"),
-    //   );
-    //   expect(isModuleInstalled).to.be.true;
+    it("Should check signature validity using smart account isValidSignature", async function () {
+      const isModuleInstalled = await smartAccount.isModuleInstalled(
+        ModuleType.Validation,
+        await validatorModule.getAddress(),
+        ethers.hexlify("0x"),
+      );
+      expect(isModuleInstalled).to.be.true;
 
-    //   // 1. Convert foundry util to ts code (as below)
+      // 1. Convert foundry util to ts code (as below)
 
-    //   const data = keccak256("0x1234");
+      const data = keccak256("0x1234");
 
-    //   // Define constants as per the original Solidity function
-    //   const DOMAIN_NAME = "Nexus";
-    //   const DOMAIN_VERSION = "1.0.0-beta";
-    //   const DOMAIN_TYPEHASH =
-    //     "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)";
-    //   const PARENT_TYPEHASH = "PersonalSign(bytes prefixed)";
-    //   const ALICE_ACCOUNT = smartAccountAddress;
-    //   const network = await ethers.provider.getNetwork();
-    //   const chainId = network.chainId;
+      // Define constants as per the original Solidity function
+      const DOMAIN_NAME = "Nexus";
+      const DOMAIN_VERSION = "1.0.0-beta";
+      const DOMAIN_TYPEHASH =
+        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)";
+      const PARENT_TYPEHASH = "PersonalSign(bytes prefixed)";
+      const ALICE_ACCOUNT = smartAccountAddress;
+      const network = await ethers.provider.getNetwork();
+      const chainId = network.chainId;
 
-    //   // Calculate the domain separator
-    //   const domainSeparator = ethers.keccak256(
-    //     ethers.AbiCoder.defaultAbiCoder().encode(
-    //       ["bytes32", "bytes32", "bytes32", "uint256", "address"],
-    //       [
-    //         ethers.keccak256(ethers.toUtf8Bytes(DOMAIN_TYPEHASH)),
-    //         ethers.keccak256(ethers.toUtf8Bytes(DOMAIN_NAME)),
-    //         ethers.keccak256(ethers.toUtf8Bytes(DOMAIN_VERSION)),
-    //         chainId,
-    //         ALICE_ACCOUNT,
-    //       ],
-    //     ),
-    //   );
+      // Calculate the domain separator
+      const domainSeparator = ethers.keccak256(
+        ethers.AbiCoder.defaultAbiCoder().encode(
+          ["bytes32", "bytes32", "bytes32", "uint256", "address"],
+          [
+            ethers.keccak256(ethers.toUtf8Bytes(DOMAIN_TYPEHASH)),
+            ethers.keccak256(ethers.toUtf8Bytes(DOMAIN_NAME)),
+            ethers.keccak256(ethers.toUtf8Bytes(DOMAIN_VERSION)),
+            chainId,
+            ALICE_ACCOUNT,
+          ],
+        ),
+      );
 
-    //   // Calculate the parent struct hash
-    //   const parentStructHash = ethers.keccak256(
-    //     ethers.AbiCoder.defaultAbiCoder().encode(
-    //       ["bytes32", "bytes32"],
-    //       [ethers.keccak256(ethers.toUtf8Bytes(PARENT_TYPEHASH)), data],
-    //     ),
-    //   );
+      // Calculate the parent struct hash
+      const parentStructHash = ethers.keccak256(
+        ethers.AbiCoder.defaultAbiCoder().encode(
+          ["bytes32", "bytes32"],
+          [ethers.keccak256(ethers.toUtf8Bytes(PARENT_TYPEHASH)), data],
+        ),
+      );
 
-    //   // Calculate the final hash
-    //   const resultHash = ethers.keccak256(
-    //     ethers.concat(["0x1901", domainSeparator, parentStructHash]),
-    //   );
+      // Calculate the final hash
+      const resultHash = ethers.keccak256(
+        ethers.concat(["0x1901", domainSeparator, parentStructHash]),
+      );
 
-    //   console.log(
-    //     "being signed",
-    //     ethers.hashMessage(ethers.getBytes(resultHash)),
-    //   );
+      console.log(
+        "being signed",
+        ethers.hashMessage(ethers.getBytes(resultHash)),
+      );
 
-    //   const signature = await smartAccountOwner.signMessage(
-    //     ethers.getBytes(resultHash),
-    //   );
+      const signature = await smartAccountOwner.signMessage(
+        ethers.getBytes(resultHash),
+      );
 
-    //   const isValid = await smartAccount.isValidSignature(
-    //     data,
-    //     solidityPacked(
-    //       ["address", "bytes"],
-    //       [await validatorModule.getAddress(), signature],
-    //     ),
-    //   );
+      const isValid = await smartAccount.isValidSignature(
+        data,
+        solidityPacked(
+          ["address", "bytes"],
+          [await validatorModule.getAddress(), signature],
+        ),
+      );
 
-    //   expect(isValid).to.equal("0x1626ba7e");
-    // });
+      expect(isValid).to.equal("0x1626ba7e");
+    });
   });
 
   describe("Smart Account check Only Entrypoint actions", function () {


### PR DESCRIPTION
**Description:**
- When calling `execute()` with `EXECTYPE_TRY` and either `CALLTYPE_SINGLE` or `CALLTYPE_DELEGATECALL`, no event is emitted if the try fails.
- With `CALLTYPE_BATCH`, the `TryExecuteUnsuccessful` event is emitted for each failure.
- In `executeFromExecutor`, `TryDelegateCallUnsuccessful` and `TryExecuteUnsuccessful` events are emitted appropriately.