### PR TITLE
Fix/security h02

### DIFF
--- a/contracts/factory/K1ValidatorFactory.sol
+++ b/contracts/factory/K1ValidatorFactory.sol
@@ -103,9 +103,6 @@ contract K1ValidatorFactory is Stakeable {
         if (!alreadyDeployed) {
             INexus(account).initializeAccount(initData);
             emit AccountCreated(account, eoaOwner, index);
-        } else if (msg.value > 0) {
-            (bool success, ) = eoaOwner.call{ value: msg.value }("");
-            require(success, InnerCallFailed());
         }
         return payable(account);
     }

--- a/test/foundry/unit/concrete/factory/TestK1ValidatorFactory_Deployments.t.sol
+++ b/test/foundry/unit/concrete/factory/TestK1ValidatorFactory_Deployments.t.sol
@@ -110,18 +110,17 @@ contract TestK1ValidatorFactory_Deployments is NexusTest_Base {
         assertEq(deployedAccountAddress, expectedAddress, "Computed address mismatch");
     }
 
-/// @notice Tests that creating an account with the same owner and index results in the same address.
-function test_CreateAccount_SameOwnerAndIndex() public payable {
-    uint256 index = 0;
-    address expectedOwner = user.addr;
+    /// @notice Tests that creating an account with the same owner and index results in the same address.
+    function test_CreateAccount_SameOwnerAndIndex() public payable {
+        uint256 index = 0;
+        address expectedOwner = user.addr;
 
-    // Create the first account with the given owner and index
-    address payable firstAccountAddress = validatorFactory.createAccount{ value: 1 ether }(expectedOwner, index, ATTESTERS, THRESHOLD);
+        address payable firstAccountAddress = validatorFactory.createAccount{ value: 1 ether }(expectedOwner, index, ATTESTERS, THRESHOLD);
+        address payable secondAccountAddress = validatorFactory.createAccount{ value: 1 ether }(expectedOwner, index, ATTESTERS, THRESHOLD);
 
-    // Expect the second call to revert with InnerCallFailed
-    vm.expectRevert(K1ValidatorFactory.InnerCallFailed.selector);
-    address payable secondAccountAddress = validatorFactory.createAccount{ value: 1 ether }(expectedOwner, index, ATTESTERS, THRESHOLD);
-}
+        assertEq(firstAccountAddress, secondAccountAddress, "Addresses should match for the same owner and index");
+        assertEq(firstAccountAddress.balance, 2 ether, "Account balance should be 2 ether");
+    }
 
     /// @notice Tests that creating accounts with different indexes results in different addresses.
     function test_CreateAccount_DifferentIndexes() public payable {


### PR DESCRIPTION
Revert the changes as `createDeterministicERC1967()` will forward the ETH to the account if it is already deployed.
