### PR TITLE
hooking fallback + remove receiver base + disallow bytes4(0) selector

### DIFF
--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -74,8 +74,6 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
         FallbackHandler storage $fallbackHandler = _getAccountStorage().fallbacks[msg.sig];
         address handler = $fallbackHandler.handler;
         CallType calltype = $fallbackHandler.calltype;
-        // review
-        // require(handler != address(0), MissingFallbackHandler(msg.sig));
         if(handler != address(0)) {
             if (calltype == CALLTYPE_STATIC) {
                assembly {
@@ -109,7 +107,7 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
                 return(0, returndatasize())
                 }
             }
-        }
+        } 
         /// @solidity memory-safe-assembly
         assembly {
             let s := shr(224, calldataload(0))
@@ -121,8 +119,7 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
                 return(0x3c, 0x20) // Return `msg.sig`.
             }
         }
-        // review
-        // could revert with unsupported func selector / calltype etc
+        revert MissingFallbackHandler(msg.sig);   
     }
 
     /// @dev Retrieves a paginated list of validator addresses from the linked list.
@@ -299,7 +296,7 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
         // Extract the initialization data from the provided parameters.
         bytes memory initData = params[5:];
 
-        // Revert if the selector is either `onInstall(bytes)` (0x6d61fe70) or `onUninstall(bytes)` (0x8a91b0e3).
+        // Revert if the selector is either `onInstall(bytes)` (0x6d61fe70) or `onUninstall(bytes)` (0x8a91b0e3) or explicit bytes(0).
         // These selectors are explicitly forbidden to prevent security vulnerabilities.
         // Allowing these selectors would enable unauthorized users to uninstall and reinstall critical modules.
         // If a validator module is uninstalled and reinstalled without proper authorization, it can compromise

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -12,7 +12,6 @@ pragma solidity ^0.8.26;
 // Nexus: A suite of contracts for Modular Smart Accounts compliant with ERC-7579 and ERC-4337, developed by Biconomy.
 // Learn more at https://biconomy.io. To report security issues, please contact us at: security@biconomy.io
 
-import { Receiver } from "solady/src/accounts/Receiver.sol";
 import { SentinelListLib } from "sentinellist/src/SentinelList.sol";
 
 import { Storage } from "./Storage.sol";
@@ -45,7 +44,7 @@ import { RegistryAdapter } from "./RegistryAdapter.sol";
 /// @author @zeroknots | Rhinestone.wtf | zeroknots.eth
 /// Special thanks to the Solady team for foundational contributions: https://github.com/Vectorized/solady
 
-abstract contract ModuleManager is Storage, Receiver, EIP712, IModuleManagerEventsAndErrors, RegistryAdapter {
+abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndErrors, RegistryAdapter {
     using SentinelListLib for SentinelListLib.SentinelList;
     using LocalCallDataParserLib for bytes;
 
@@ -68,15 +67,18 @@ abstract contract ModuleManager is Storage, Receiver, EIP712, IModuleManagerEven
         }
     }
 
+    receive() external payable {}
+
     /// @dev Fallback function to manage incoming calls using designated handlers based on the call type.
-    fallback() external payable override(Receiver) receiverFallback {
+    fallback() external payable withHook {
         FallbackHandler storage $fallbackHandler = _getAccountStorage().fallbacks[msg.sig];
         address handler = $fallbackHandler.handler;
         CallType calltype = $fallbackHandler.calltype;
-        require(handler != address(0), MissingFallbackHandler(msg.sig));
-
-        if (calltype == CALLTYPE_STATIC) {
-            assembly {
+        // review
+        // require(handler != address(0), MissingFallbackHandler(msg.sig));
+        if(handler != address(0)) {
+            if (calltype == CALLTYPE_STATIC) {
+               assembly {
                 calldatacopy(0, 0, calldatasize())
 
                 // The msg.sender address is shifted to the left by 12 bytes to remove the padding
@@ -89,10 +91,10 @@ abstract contract ModuleManager is Storage, Receiver, EIP712, IModuleManagerEven
                 }
                 returndatacopy(0, 0, returndatasize())
                 return(0, returndatasize())
+                }
             }
-        }
-        if (calltype == CALLTYPE_SINGLE) {
-            assembly {
+            if (calltype == CALLTYPE_SINGLE) {
+               assembly {
                 calldatacopy(0, 0, calldatasize())
 
                 // The msg.sender address is shifted to the left by 12 bytes to remove the padding
@@ -105,8 +107,22 @@ abstract contract ModuleManager is Storage, Receiver, EIP712, IModuleManagerEven
                 }
                 returndatacopy(0, 0, returndatasize())
                 return(0, returndatasize())
+                }
             }
         }
+        /// @solidity memory-safe-assembly
+        assembly {
+            let s := shr(224, calldataload(0))
+            // 0x150b7a02: `onERC721Received(address,address,uint256,bytes)`.
+            // 0xf23a6e61: `onERC1155Received(address,address,uint256,uint256,bytes)`.
+            // 0xbc197c81: `onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)`.
+            if or(eq(s, 0x150b7a02), or(eq(s, 0xf23a6e61), eq(s, 0xbc197c81))) {
+                mstore(0x20, s) // Store `msg.sig`.
+                return(0x3c, 0x20) // Return `msg.sig`.
+            }
+        }
+        // review
+        // could revert with unsupported func selector / calltype etc
     }
 
     /// @dev Retrieves a paginated list of validator addresses from the linked list.
@@ -289,7 +305,7 @@ abstract contract ModuleManager is Storage, Receiver, EIP712, IModuleManagerEven
         // If a validator module is uninstalled and reinstalled without proper authorization, it can compromise
         // the account's security and integrity. By restricting these selectors, we ensure that the fallback handler
         // cannot be manipulated to disrupt the expected behavior and security of the account.
-        require(!(selector == bytes4(0x6d61fe70) || selector == bytes4(0x8a91b0e3)), FallbackSelectorForbidden());
+        require(!(selector == bytes4(0x6d61fe70) || selector == bytes4(0x8a91b0e3) || selector == bytes4(0)), FallbackSelectorForbidden());
 
         // Revert if a fallback handler is already installed for the given selector.
         // This check ensures that we do not overwrite an existing fallback handler, which could lead to unexpected behavior.

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -293,6 +293,8 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
         // Extract the call type from the provided parameters.
         CallType calltype = CallType.wrap(bytes1(params[4]));
 
+        require(calltype == CALLTYPE_SINGLE || calltype == CALLTYPE_STATIC, FallbackCallTypeInvalid());
+
         // Extract the initialization data from the provided parameters.
         bytes memory initData = params[5:];
 

--- a/contracts/interfaces/base/IModuleManagerEventsAndErrors.sol
+++ b/contracts/interfaces/base/IModuleManagerEventsAndErrors.sol
@@ -81,4 +81,7 @@ interface IModuleManagerEventsAndErrors {
 
     /// @dev Thrown when there is an attempt to install a forbidden selector as a fallback handler.
     error FallbackSelectorForbidden();
+
+    /// @dev Thrown when there is an attempt to install a fallback handler with an invalid calltype for a given selector.
+    error FallbackCallTypeInvalid();
 }

--- a/test/foundry/integration/UpgradeSmartAccountTest.t.sol
+++ b/test/foundry/integration/UpgradeSmartAccountTest.t.sol
@@ -46,6 +46,7 @@ contract UpgradeSmartAccountTest is NexusTest_Base {
         Execution[] memory execution = new Execution[](1);
         execution[0] = Execution(address(BOB_ACCOUNT), 0, callData);
         PackedUserOperation[] memory userOps = buildPackedUserOperation(BOB, BOB_ACCOUNT, EXECTYPE_DEFAULT, execution, address(VALIDATOR_MODULE));
+        // Review: this test is impacted
         bytes memory expectedRevertReason = abi.encodeWithSelector(MissingFallbackHandler.selector, bytes4(hex"1234"));
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
         // Expect the UserOperationRevertReason event

--- a/test/foundry/integration/UpgradeSmartAccountTest.t.sol
+++ b/test/foundry/integration/UpgradeSmartAccountTest.t.sol
@@ -46,7 +46,6 @@ contract UpgradeSmartAccountTest is NexusTest_Base {
         Execution[] memory execution = new Execution[](1);
         execution[0] = Execution(address(BOB_ACCOUNT), 0, callData);
         PackedUserOperation[] memory userOps = buildPackedUserOperation(BOB, BOB_ACCOUNT, EXECTYPE_DEFAULT, execution, address(VALIDATOR_MODULE));
-        // Review: this test is impacted
         bytes memory expectedRevertReason = abi.encodeWithSelector(MissingFallbackHandler.selector, bytes4(hex"1234"));
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
         // Expect the UserOperationRevertReason event

--- a/test/foundry/unit/concrete/fallback/TestNexus_FallbackFunction.t.sol
+++ b/test/foundry/unit/concrete/fallback/TestNexus_FallbackFunction.t.sol
@@ -119,7 +119,6 @@ contract TestNexus_FallbackFunction is TestModuleManagement_Base {
     function test_FallbackHandlerMissingHandler() public {
         bytes4 selector = bytes4(keccak256("nonexistentFunction()"));
         (bool success, ) = address(BOB_ACCOUNT).call(abi.encodeWithSelector(selector));
-        // Review: since now we are not reverting this does not fail anymore. 
         assertFalse(success, "Call to missing fallback handler should fail");
     }
 

--- a/test/foundry/unit/concrete/fallback/TestNexus_FallbackFunction.t.sol
+++ b/test/foundry/unit/concrete/fallback/TestNexus_FallbackFunction.t.sol
@@ -85,16 +85,34 @@ contract TestNexus_FallbackFunction is TestModuleManagement_Base {
         assertFalse(success, "State change through fallback static call should fail");
     }
 
-    /// @notice Tests fallback handler with an invalid call type.
+    /// @notice Tests installing fallback handler with an invalid call type.
     function test_FallbackHandlerInvalidCallType() public {
         bytes4 selector = mockFallbackHandler.stateChangingFunction.selector;
         // Use an invalid call type (0xFF is not defined)
         bytes memory customData = abi.encodePacked(selector, bytes1(0xFF));
-        installFallbackHandler(customData);
 
-        // Make a call to the fallback function with an invalid call type
-        (bool success, ) = address(BOB_ACCOUNT).call(abi.encodeWithSelector(selector));
-        assertTrue(success, "Call with invalid call type should fail");
+        bytes memory callData = abi.encodeWithSelector(
+            IModuleManager.installModule.selector,
+            MODULE_TYPE_FALLBACK,
+            address(mockFallbackHandler),
+            customData
+        );
+        Execution[] memory execution = new Execution[](1);
+        execution[0] = Execution(address(BOB_ACCOUNT), 0, callData);
+        PackedUserOperation[] memory userOps = buildPackedUserOperation(BOB, BOB_ACCOUNT, EXECTYPE_DEFAULT, execution, address(VALIDATOR_MODULE));
+
+        bytes memory expectedRevertReason = abi.encodeWithSelector(FallbackCallTypeInvalid.selector);
+        bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
+        // Expect the UserOperationRevertReason event
+        vm.expectEmit(true, true, true, true);
+        emit UserOperationRevertReason(
+            userOpHash, // userOpHash
+            address(BOB_ACCOUNT), // sender
+            userOps[0].nonce, // nonce
+            expectedRevertReason
+        );
+        
+        ENTRYPOINT.handleOps(userOps, payable(address(BOB.addr)));
     }
 
     /// @notice Tests fallback handler when the handler is missing.

--- a/test/foundry/unit/concrete/fallback/TestNexus_FallbackFunction.t.sol
+++ b/test/foundry/unit/concrete/fallback/TestNexus_FallbackFunction.t.sol
@@ -101,6 +101,7 @@ contract TestNexus_FallbackFunction is TestModuleManagement_Base {
     function test_FallbackHandlerMissingHandler() public {
         bytes4 selector = bytes4(keccak256("nonexistentFunction()"));
         (bool success, ) = address(BOB_ACCOUNT).call(abi.encodeWithSelector(selector));
+        // Review: since now we are not reverting this does not fail anymore. 
         assertFalse(success, "Call to missing fallback handler should fail");
     }
 

--- a/test/foundry/unit/fuzz/TestFuzz_ModuleManager.t.sol
+++ b/test/foundry/unit/fuzz/TestFuzz_ModuleManager.t.sol
@@ -40,7 +40,7 @@ contract TestFuzz_ModuleManager is TestModuleManagement_Base {
     /// @notice Fuzz test for installing fallback handlers with random function selectors
     /// @param selector The random function selector
     function testFuzz_InstallFallbackHandler_WithRandomSelector(bytes4 selector) public {
-        vm.assume(selector != bytes4(0x6d61fe70) && selector != bytes4(0x8a91b0e3));
+        vm.assume(selector != bytes4(0x6d61fe70) && selector != bytes4(0x8a91b0e3) && selector != bytes4(0)); // Exclude known selectors
         // Prepare data with a random selector to test dynamic input handling
         bytes memory customData = abi.encode(selector);
         bytes memory callData = abi.encodeWithSelector(

--- a/test/foundry/utils/EventsAndErrors.sol
+++ b/test/foundry/utils/EventsAndErrors.sol
@@ -21,6 +21,7 @@ contract EventsAndErrors {
     // General Errors
     // ==========================
     error MissingFallbackHandler(bytes4 sig);
+    error FallbackCallTypeInvalid();
     error InvalidImplementationAddress();
     error AccountInitializationFailed();
     error AccountAccessUnauthorized();


### PR DESCRIPTION
+ review dev notes on tests


removed receiver base and receiverFallback modifier
Hooking fallback now ( I think we can remove all blacklisted all together from installFallback @filmakarov )
added receiver function
(for now) not throwing on unfound selector [ check comments [here](https://cantina.xyz/code/d1d4b139-9705-4367-9468-297b7078674e/findings/13) ] 
running the code for token callbacks at the end.
left a room and dev notes for throwing in case of unregistered selector and unsupported calltype.  
