### PR TITLE
Fix/cantina fixes

### DIFF
--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -217,9 +217,8 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
         (address bootstrap, bytes memory bootstrapCall) = abi.decode(initData, (address, bytes));
         (bool success, ) = bootstrap.delegatecall(bootstrapCall);
         
-        SentinelListLib.SentinelList storage validators = _getAccountStorage().validators;
-        require(!(prev == address(0x01) && validators.getNext(validator) == address(0x01)), CannotRemoveLastValidator());
         require(success, NexusInitializationFailed());
+        require(_hasValidators(), MissingValidator());
     }
 
     function setRegistry(IERC7484 newRegistry, address[] calldata attesters, uint8 threshold) external payable onlyEntryPointOrSelf {

--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -78,8 +78,6 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
     }
 
     /// Validates a user operation against a specified validator, extracted from the operation's nonce.
-    /// The entryPoint calls this only if validation succeeds. Fails by returning `VALIDATION_FAILED` for invalid signatures.
-    /// Other validation failures (e.g., nonce mismatch) should revert.
     /// @param op The operation to validate, encapsulating all transaction details.
     /// @param userOpHash Hash of the operation data, used for signature validation.
     /// @param missingAccountFunds Funds missing from the account's deposit necessary for transaction execution.
@@ -326,7 +324,7 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
         UUPSUpgradeable.upgradeToAndCall(newImplementation, data);
     }
 
-    /// @notice Wrapper around `_eip712Hash()` to produce a replay-safe hash fron the given `hash`.
+    /// @notice Wrapper around `_eip712Hash()` to produce a replay-safe hash from the given `hash`.
     ///
     /// @dev The returned EIP-712 compliant replay-safe hash is the result of:
     ///      keccak256(

--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -77,21 +77,24 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
         _initModuleManager();
     }
 
-    /// Validates a user operation against a specified validator, extracted from the operation's nonce.
-    /// @param op The operation to validate, encapsulating all transaction details.
-    /// @param userOpHash Hash of the operation data, used for signature validation.
+    /// @notice Validates a user operation against a specified validator, extracted from the operation's nonce.
+    /// @param op The user operation to validate, encapsulating all transaction details.
+    /// @param userOpHash Hash of the user operation data, used for signature validation.
     /// @param missingAccountFunds Funds missing from the account's deposit necessary for transaction execution.
-    /// This can be zero if covered by a paymaster or sufficient deposit exists.
+    /// This can be zero if covered by a paymaster or if sufficient deposit exists.
     /// @return validationData Encoded validation result or failure, propagated from the validator module.
     /// - Encoded format in validationData:
-    ///     - First 20 bytes: Validator address, 0x0 for valid or specific failure modes.
-    ///     - `SIG_VALIDATION_FAILED` (1) denotes signature validation failure allowing simulation calls without a valid signature.
-    /// @dev Expects the validator's address to be encoded in the upper 96 bits of the userOp's nonce.
+    ///     - First 20 bytes: Address of the Validator module, to which the validation task is forwarded.
+    ///       The validator module returns:
+    ///         - `SIG_VALIDATION_SUCCESS` (0) indicates successful validation.
+    ///         - `SIG_VALIDATION_FAILED` (1) indicates signature validation failure.
+    /// @dev Expects the validator's address to be encoded in the upper 96 bits of the user operation's nonce.
     /// This method forwards the validation task to the extracted validator module address.
+    /// @dev The entryPoint calls this function. If validation fails, it returns `VALIDATION_FAILED` (1) otherwise `0`.
     /// @dev Features Module Enable Mode.
-    /// This Module Enable Mode flow only makes sense for the module that is used as validator
-    /// for the userOp that triggers Module Enable Flow. Otherwise, one should just include
-    /// a call to Nexus.installModule into userOp.callData
+    /// This Module Enable Mode flow is intended for the module acting as the validator
+    /// for the user operation that triggers the Module Enable Flow. Otherwise, a call to 
+    /// `Nexus.installModule` should be included in `userOp.callData`.
     function validateUserOp(
         PackedUserOperation calldata op,
         bytes32 userOpHash,

--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -218,6 +218,9 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
         _initModuleManager();
         (address bootstrap, bytes memory bootstrapCall) = abi.decode(initData, (address, bytes));
         (bool success, ) = bootstrap.delegatecall(bootstrapCall);
+        
+        SentinelListLib.SentinelList storage validators = _getAccountStorage().validators;
+        require(!(prev == address(0x01) && validators.getNext(validator) == address(0x01)), CannotRemoveLastValidator());
         require(success, NexusInitializationFailed());
     }
 

--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -200,9 +200,7 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
     /// @param deInitData De-initialization data for the module.
     /// @dev Ensures that the operation is authorized and valid before proceeding with the uninstallation.
     function uninstallModule(uint256 moduleTypeId, address module, bytes calldata deInitData) external payable onlyEntryPointOrSelf withHook {
-        require(IModule(module).isModuleType(moduleTypeId), MismatchModuleTypeId(moduleTypeId));
         require(_isModuleInstalled(moduleTypeId, module, deInitData), ModuleNotInstalled(moduleTypeId, module));
-
         emit ModuleUninstalled(moduleTypeId, module);
 
         if (moduleTypeId == MODULE_TYPE_VALIDATOR) {

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -473,7 +473,7 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
     /// @dev Checks if there is at least one validator installed.
     /// @return True if there is at least one validator, otherwise false.
     function _hasValidators() internal view returns (bool) {
-        return _getAccountStorage().validators.getNext(address(0x01)) != address(0x01);
+        return _getAccountStorage().validators.getNext(address(0x01)) != address(0x01) && _getAccountStorage().validators.getNext(address(0x01)) != address(0x00);
     }
 
     /// @dev Checks if an executor is currently installed.

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -232,13 +232,15 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
 
         (address prev, bytes memory disableModuleData) = abi.decode(data, (address, bytes));
 
-        // Check if the account has at least one validator installed before proceeding
-        // Having at least one validator is a requirement for the account to function properly
-        require(!(prev == address(0x01) && validators.getNext(validator) == address(0x01)), CannotRemoveLastValidator());
-
+        // Perform the removal first
         validators.pop(prev, validator);
+
+        // Sentinel pointing to itself means the list is empty, so check this after removal
+        require(validators.getNext(address(0x01)) != address(0x01), CannotRemoveLastValidator());
+
         (bool success, ) = validator.call(abi.encodeWithSelector(IModule.onUninstall.selector, disableModuleData));
     }
+
 
     /// @dev Installs a new executor module after checking if it matches the required module type.
     /// @param executor The address of the executor module to be installed.

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -330,18 +330,11 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
         (bool success, ) = fallbackHandler.call(abi.encodeWithSelector(IModule.onUninstall.selector, data[4:]));
     }
 
-    /// To make it easier to install multiple modules at once, this function will
-    /// install multiple modules at once. The init data is expected to be a abi encoded tuple
-    /// of (uint[] types, bytes[] initDatas)
-    /// @dev Install multiple modules at once
-    /// @dev It will call module.onInstall for every initialization so it ensure the flow
-    /// consistent with the flow of the SA's that do not implement _multiTypeInstall 
-    /// and thus will call the multityped module several times
-    /// The multityped modules can not expect all the 7579 SA's to implement _multiTypeInstall and
-    /// thus should account for the flow when they are going to be called with onUnistall
-    /// for the initialization as every of the module types they declare they are 
-    /// @param module address of the module
-    /// @param initData initialization data for the module
+    /// @notice Installs a module with multiple types in a single operation.
+    /// @dev This function handles installing a multi-type module by iterating through each type and initializing it.
+    /// The initData should include an ABI-encoded tuple of (uint[] types, bytes[] initDatas).
+    /// @param module The address of the multi-type module.
+    /// @param initData Initialization data for each type within the module.
     function _multiTypeInstall(
         address module,
         bytes calldata initData
@@ -376,7 +369,7 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
                 _installFallbackHandler(module, initDatas[i]);
             }
             /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
-            /*          INSTALL HOOK (global or sig specific)             */
+            /*          INSTALL HOOK (global only, not sig-specific)      */
             /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
             else if (theType == MODULE_TYPE_HOOK) {
                 _installHook(module, initDatas[i]);

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -236,7 +236,7 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
         validators.pop(prev, validator);
 
         // Sentinel pointing to itself means the list is empty, so check this after removal
-        require(_hasValidators(), MissingValidator());
+        require(_hasValidators(), CanNotRemoveLastValidator());
 
         (bool success, ) = validator.call(abi.encodeWithSelector(IModule.onUninstall.selector, disableModuleData));
     }

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -236,7 +236,7 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
         validators.pop(prev, validator);
 
         // Sentinel pointing to itself means the list is empty, so check this after removal
-        require(validators.getNext(address(0x01)) != address(0x01), CannotRemoveLastValidator());
+        require(_hasValidators(), MissingValidator());
 
         (bool success, ) = validator.call(abi.encodeWithSelector(IModule.onUninstall.selector, disableModuleData));
     }
@@ -456,6 +456,12 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
     /// @return True if the validator is installed, otherwise false.
     function _isValidatorInstalled(address validator) internal view virtual returns (bool) {
         return _getAccountStorage().validators.contains(validator);
+    }
+
+    /// @dev Checks if there is at least one validator installed.
+    /// @return True if there is at least one validator, otherwise false.
+    function _hasValidators() internal view returns (bool) {
+        return _getAccountStorage().validators.getNext(address(0x01)) != address(0x01);
     }
 
     /// @dev Checks if an executor is currently installed.

--- a/contracts/base/RegistryAdapter.sol
+++ b/contracts/base/RegistryAdapter.sol
@@ -3,24 +3,28 @@ pragma solidity ^0.8.26;
 
 import { IERC7484 } from "../interfaces/IERC7484.sol";
 
-/**
- * IERC7484 Registry adapter.
- * this feature is opt-in. The smart account owner can choose to use the registry and which
- * attesters to trust
- */
+/// @title RegistryAdapter
+/// @notice This contract provides an interface for interacting with an ERC-7484 compliant registry.
+/// @dev The registry feature is opt-in, allowing the smart account owner to select and trust specific attesters.
 abstract contract RegistryAdapter {
     IERC7484 public registry;
 
+    /// @notice Emitted when a new ERC-7484 registry is configured for the account.
+    /// @param registry The configured registry contract.
     event ERC7484RegistryConfigured(IERC7484 indexed registry);
 
+    /// @notice Modifier to check if a module meets the required attestations in the registry.
+    /// @param module The module to check.
+    /// @param moduleType The type of the module to verify in the registry.
     modifier withRegistry(address module, uint256 moduleType) {
         _checkRegistry(module, moduleType);
         _;
     }
 
-    /**
-     * Configure ERC7484 Registry for Account
-     */
+    /// @notice Configures the ERC-7484 registry and sets trusted attesters.
+    /// @param newRegistry The new registry contract to use.
+    /// @param attesters The list of attesters to trust.
+    /// @param threshold The number of attestations required.
     function _configureRegistry(IERC7484 newRegistry, address[] calldata attesters, uint8 threshold) internal {
         registry = newRegistry;
         if (address(newRegistry) != address(0)) {
@@ -29,14 +33,14 @@ abstract contract RegistryAdapter {
         emit ERC7484RegistryConfigured(newRegistry);
     }
 
-    /**
-     * Check on ERC7484 Registry, if suffcient attestations were made
-     * This will revert, if not succicient valid attestations are on the registry
-     */
+    /// @notice Checks the registry to ensure sufficient valid attestations for a module.
+    /// @param module The module to check.
+    /// @param moduleType The type of the module to verify in the registry.
+    /// @dev Reverts if the required attestations are not met.
     function _checkRegistry(address module, uint256 moduleType) internal view {
         IERC7484 moduleRegistry = registry;
         if (address(moduleRegistry) != address(0)) {
-            // this will revert if attestations / threshold are not met
+            // This will revert if attestations or the threshold are not met.
             moduleRegistry.check(module, moduleType);
         }
     }

--- a/contracts/factory/K1ValidatorFactory.sol
+++ b/contracts/factory/K1ValidatorFactory.sol
@@ -60,7 +60,7 @@ contract K1ValidatorFactory is Stakeable {
         IERC7484 registry
     ) Stakeable(factoryOwner) {
         require(
-            !(implementation == address(0) || k1Validator == address(0) || address(bootstrapper) == address(0) || address(registry) == address(0)),
+            !(implementation == address(0) || k1Validator == address(0) || address(bootstrapper) == address(0) || address(registry) == address(0) || factoryOwner == address(0)),
             ZeroAddressNotAllowed()
         );
         ACCOUNT_IMPLEMENTATION = implementation;

--- a/contracts/factory/RegistryFactory.sol
+++ b/contracts/factory/RegistryFactory.sol
@@ -42,12 +42,18 @@ contract RegistryFactory is Stakeable, INexusFactory {
     /// @param module The module address that is not whitelisted.
     error ModuleNotWhitelisted(address module);
 
+    /// @notice Error thrown when the threshold exceeds the number of attesters.
+    /// @param threshold The provided threshold value.
+    /// @param attestersLength The number of attesters provided.
+    error InvalidThreshold(uint8 threshold, uint256 attestersLength);
+
     /// @notice Constructor to set the smart account implementation address and owner.
     /// @param implementation_ The address of the Nexus implementation to be used for all deployments.
     /// @param owner_ The address of the owner of the factory.
     constructor(address implementation_, address owner_, IERC7484 registry_, address[] memory attesters_, uint8 threshold_) Stakeable(owner_) {
         require(implementation_ != address(0), ImplementationAddressCanNotBeZero());
         require(owner_ != address(0), ZeroAddressNotAllowed());
+        require(threshold_ <= attesters_.length, InvalidThreshold(threshold_, attesters_.length));
         REGISTRY = registry_;
         attesters = attesters_;
         threshold = threshold_;

--- a/contracts/interfaces/base/IModuleManagerEventsAndErrors.sol
+++ b/contracts/interfaces/base/IModuleManagerEventsAndErrors.sol
@@ -31,9 +31,6 @@ interface IModuleManagerEventsAndErrors {
     /// @param module The address of the uninstalled module.
     event ModuleUninstalled(uint256 moduleTypeId, address module);
 
-    /// @notice Thrown when no validators exist on the initialization of a smart account.
-    error MissingValidator();
-
     /// @notice Thrown when attempting to remove the last validator.
     error CanNotRemoveLastValidator();
 

--- a/contracts/interfaces/base/IModuleManagerEventsAndErrors.sol
+++ b/contracts/interfaces/base/IModuleManagerEventsAndErrors.sol
@@ -31,8 +31,8 @@ interface IModuleManagerEventsAndErrors {
     /// @param module The address of the uninstalled module.
     event ModuleUninstalled(uint256 moduleTypeId, address module);
 
-    /// @dev Thrown when an attempt is made to uninstall the last validator module, which is prohibited.
-    error CannotRemoveLastValidator();
+    /// @notice Thrown when no validators exist or when attempting to remove the last one.
+    error MissingValidator();
 
     /// @dev Thrown when the specified module address is not recognized as valid.
     error InvalidModule(address module);

--- a/contracts/interfaces/base/IModuleManagerEventsAndErrors.sol
+++ b/contracts/interfaces/base/IModuleManagerEventsAndErrors.sol
@@ -31,8 +31,11 @@ interface IModuleManagerEventsAndErrors {
     /// @param module The address of the uninstalled module.
     event ModuleUninstalled(uint256 moduleTypeId, address module);
 
-    /// @notice Thrown when no validators exist or when attempting to remove the last one.
+    /// @notice Thrown when no validators exist on the initialization of a smart account.
     error MissingValidator();
+
+    /// @notice Thrown when attempting to remove the last validator.
+    error CanNotRemoveLastValidator();
 
     /// @dev Thrown when the specified module address is not recognized as valid.
     error InvalidModule(address module);

--- a/contracts/interfaces/base/IStorage.sol
+++ b/contracts/interfaces/base/IStorage.sol
@@ -40,6 +40,6 @@ interface IStorage {
     /// @notice Defines a fallback handler with an associated handler address and a call type.
     struct FallbackHandler {
         address handler; ///< The address of the fallback function handler.
-        CallType calltype; ///< The type of call this handler supports (e.g., static or delegatecall).
+        CallType calltype; ///< The type of call this handler supports (e.g., static or call).
     }
 }

--- a/contracts/lib/ExecLib.sol
+++ b/contracts/lib/ExecLib.sol
@@ -16,7 +16,7 @@ library ExecLib {
          * 0x4                  | -                 |
         abi.encode(IERC7579Execution.Execution[])
          */
-        assembly {
+        assembly ("memory-safe") {
             let dataPointer := add(callData.offset, calldataload(callData.offset))
 
             // Extract the ERC7579 Executions

--- a/contracts/lib/ModuleTypeLib.sol
+++ b/contracts/lib/ModuleTypeLib.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.26;
 
 type EncodedModuleTypes is uint256;
 
-type ModuleType is uint256;
+type ModuleType is uint8;
 
 /// @title ModuleTypeLib
 /// @notice A library for handling module types and encoding them as bits

--- a/contracts/lib/NonceLib.sol
+++ b/contracts/lib/NonceLib.sol
@@ -24,7 +24,7 @@ library NonceLib {
     /// @return res boolean result, true if it is the Module Enable Mode
     function isModuleEnableMode(uint256 nonce) internal pure returns (bool res) {
         assembly {
-            let vmode := shr(248, shl(24, nonce))
+            let vmode := byte(3, nonce)
             res := eq(shl(248, vmode), MODE_MODULE_ENABLE)
         }
     }

--- a/contracts/lib/local/LocalCallDataParserLib.sol
+++ b/contracts/lib/local/LocalCallDataParserLib.sol
@@ -17,7 +17,7 @@ library LocalCallDataParserLib {
         ) 
     {
         uint256 p;
-        assembly {
+        assembly ("memory-safe") {
             p := packedData.offset
             module := shr(96, calldataload(p))
 

--- a/contracts/lib/local/LocalCallDataParserLib.sol
+++ b/contracts/lib/local/LocalCallDataParserLib.sol
@@ -3,8 +3,15 @@ pragma solidity 0.8.26;
 
 library LocalCallDataParserLib {
 
-    /// @dev Parses the data to obtain enable mode specific data
-    /// @param packedData Packed data. In most cases it will be userOp.signature
+    /// @dev Parses the `userOp.signature` to extract the module type, module initialization data,
+    ///      enable mode signature, and user operation signature. The `userOp.signature` must be
+    ///      encoded in a specific way to be parsed correctly.
+    /// @param packedData The packed signature data, typically coming from `userOp.signature`.
+    /// @return module The address of the module.
+    /// @return moduleType The type of module as a `uint256`.
+    /// @return moduleInitData Initialization data specific to the module.
+    /// @return enableModeSignature Signature used to enable the module mode.
+    /// @return userOpSignature The remaining user operation signature data.
     function parseEnableModeData(bytes calldata packedData) 
         internal 
         pure 

--- a/contracts/lib/local/LocalCallDataParserLib.sol
+++ b/contracts/lib/local/LocalCallDataParserLib.sol
@@ -36,7 +36,7 @@ library LocalCallDataParserLib {
     }
 
 
-    /// @dev Parses the data to obtain types and initdata's for Multi Type module isntall mode
+    /// @dev Parses the data to obtain types and initdata's for Multi Type module install mode
     /// @param initData Multi Type module init data, abi.encoded
     function parseMultiTypeInitData(bytes calldata initData) 
         internal

--- a/contracts/modules/validators/K1Validator.sol
+++ b/contracts/modules/validators/K1Validator.sol
@@ -21,8 +21,12 @@ import { ERC1271_MAGICVALUE, ERC1271_INVALID } from "../../../contracts/types/Co
 import { MODULE_TYPE_VALIDATOR, VALIDATION_SUCCESS, VALIDATION_FAILED } from "../../../contracts/types/Constants.sol";
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
-/// @title Nexus - K1Validator
-/// @notice This contract is a simple validator for testing purposes, verifying user operation signatures against registered owners.
+/// @title Nexus - K1Validator (ECDSA)
+/// @notice Validator module for smart accounts, verifying user operation signatures 
+///         based on the K1 curve (secp256k1), a widely used ECDSA algorithm.
+/// @dev Implements secure ownership validation by checking signatures against registered 
+///      owners. This module supports ERC-7579 and ERC-4337 standards, ensuring only the 
+///      legitimate owner of a smart account can authorize transactions.
 /// @author @livingrockrises | Biconomy | chirag@biconomy.io
 /// @author @aboudjem | Biconomy | adam.boudjemaa@biconomy.io
 /// @author @filmakarov | Biconomy | filipp.makarov@biconomy.io

--- a/contracts/modules/validators/K1Validator.sol
+++ b/contracts/modules/validators/K1Validator.sol
@@ -84,8 +84,8 @@ contract K1Validator is IValidator {
     function validateUserOp(PackedUserOperation calldata userOp, bytes32 userOpHash) external view returns (uint256) {
         address owner = smartAccountOwners[userOp.sender];
         if (
-            owner.isValidSignatureNow(ECDSA.toEthSignedMessageHash(userOpHash), userOp.signature) ||
-            owner.isValidSignatureNow(userOpHash, userOp.signature)
+            owner.isValidSignatureNowCalldata(ECDSA.toEthSignedMessageHash(userOpHash), userOp.signature) ||
+            owner.isValidSignatureNowCalldata(userOpHash, userOp.signature)
         ) {
             return VALIDATION_SUCCESS;
         }

--- a/test/foundry/unit/concrete/factory/TestK1ValidatorFactory_Deployments.t.sol
+++ b/test/foundry/unit/concrete/factory/TestK1ValidatorFactory_Deployments.t.sol
@@ -56,6 +56,17 @@ contract TestK1ValidatorFactory_Deployments is NexusTest_Base {
         new K1ValidatorFactory(zeroAddress, address(this), address(VALIDATOR_MODULE), bootstrapper, REGISTRY);
     }
 
+    /// @notice Tests that the constructor reverts if the factory owner address is zero.
+    function test_Constructor_RevertIf_FactoryOwnerIsZero() public {
+        address zeroAddress = address(0);
+
+        // Expect the contract deployment to revert with the correct error message
+        vm.expectRevert(ZeroAddressNotAllowed.selector);
+
+        // Try deploying the K1ValidatorFactory with an implementation address of zero
+        new K1ValidatorFactory(address(this), zeroAddress, address(VALIDATOR_MODULE), bootstrapper, REGISTRY);
+    }
+
     /// @notice Tests that the constructor reverts if the K1 Validator address is zero.
     function test_Constructor_RevertIf_K1ValidatorIsZero() public {
         address zeroAddress = address(0);

--- a/test/foundry/unit/concrete/factory/TestK1ValidatorFactory_Deployments.tree
+++ b/test/foundry/unit/concrete/factory/TestK1ValidatorFactory_Deployments.tree
@@ -3,6 +3,7 @@ TestK1ValidatorFactory_Deployments
     ├── when the constructor is called
     │   ├── it should initialize the factory with valid implementation, K1 Validator, and Bootstrapper addresses
     │   ├── it should revert if the implementation address is zero
+    │   ├── it should revert if the factory owner address is zero
     │   ├── it should revert if the K1 Validator address is zero
     │   └── it should revert if the Bootstrapper address is zero
     ├── when deploying an account using the factory directly

--- a/test/foundry/unit/concrete/factory/TestNexusAccountFactory_Deployments.t.sol
+++ b/test/foundry/unit/concrete/factory/TestNexusAccountFactory_Deployments.t.sol
@@ -117,6 +117,20 @@ contract TestNexusAccountFactory_Deployments is NexusTest_Base {
         INexus(firstAccountAddress).initializeAccount(factoryData);
     }
 
+    /// @notice Tests that account initialization reverts if no validator is installed.
+    function test_RevertIf_NoValidatorDuringInitialization() public {
+        BootstrapConfig[] memory emptyValidators; // Empty validators array
+        BootstrapConfig memory hook = BootstrapLib.createSingleConfig(address(0), "");
+        bytes memory saDeploymentIndex = "0";
+        bytes32 salt = keccak256(saDeploymentIndex);
+
+        // Create initcode with no validator configuration
+        bytes memory _initData = BOOTSTRAPPER.getInitNexusScopedCalldata(emptyValidators, hook, REGISTRY, ATTESTERS, THRESHOLD);
+
+        vm.expectRevert(MissingValidator.selector);
+        FACTORY.createAccount(_initData, salt);
+    }
+
     /// @notice Tests creating accounts with different indexes.
     function test_DeployAccount_DifferentIndexes() public {
         BootstrapConfig[] memory validators = BootstrapLib.createArrayConfig(address(VALIDATOR_MODULE), initData);

--- a/test/foundry/unit/concrete/factory/TestNexusAccountFactory_Deployments.tree
+++ b/test/foundry/unit/concrete/factory/TestNexusAccountFactory_Deployments.tree
@@ -17,6 +17,8 @@ TestNexusAccountFactory_Deployments
 │   └── it should revert
 ├── when deploying an account with insufficient gas
 │   └── it should revert
+├── when initializing an account without a validator module
+│   └── it should revert
 ├── when testing the constructor of the Nexus contract
 │   └── it should revert if the entry point address is zero
 ├── when using BootstrapLib.createArrayConfig function for multiple modules

--- a/test/foundry/unit/concrete/factory/TestRegistryFactory_Deployments.t.sol
+++ b/test/foundry/unit/concrete/factory/TestRegistryFactory_Deployments.t.sol
@@ -49,6 +49,18 @@ contract TestRegistryFactory_Deployments is NexusTest_Base {
         new RegistryFactory(address(0), address(this), registry, attestersArray, 1);
     }
 
+        /// @notice Tests that the constructor reverts if the threshold is greater than the length of the attesters array.
+    function test_Constructor_RevertIf_ThresholdExceedsAttestersLength() public {
+        address implementation = address(0x123);
+        address;
+        attestersArray[0] = address(0x789);
+
+        // Expect the constructor to revert because the threshold (2) is greater than the number of attesters (1)
+        vm.expectRevert(abi.encodeWithSelector(InvalidThreshold.selector, 2, attestersArray.length));
+        new RegistryFactory(implementation, address(this), registry, attestersArray, 2);
+    }
+
+
     /// @notice Tests adding and removing attesters from the registry.
     function test_AddRemoveAttester() public {
         address attester = address(0x456);

--- a/test/foundry/unit/concrete/factory/TestRegistryFactory_Deployments.t.sol
+++ b/test/foundry/unit/concrete/factory/TestRegistryFactory_Deployments.t.sol
@@ -52,7 +52,7 @@ contract TestRegistryFactory_Deployments is NexusTest_Base {
         /// @notice Tests that the constructor reverts if the threshold is greater than the length of the attesters array.
     function test_Constructor_RevertIf_ThresholdExceedsAttestersLength() public {
         address implementation = address(0x123);
-        address;
+        address[] memory attestersArray = new address[](1);
         attestersArray[0] = address(0x789);
 
         // Expect the constructor to revert because the threshold (2) is greater than the number of attesters (1)

--- a/test/foundry/unit/concrete/factory/TestRegistryFactory_Deployments.t.sol
+++ b/test/foundry/unit/concrete/factory/TestRegistryFactory_Deployments.t.sol
@@ -60,7 +60,6 @@ contract TestRegistryFactory_Deployments is NexusTest_Base {
         new RegistryFactory(implementation, address(this), registry, attestersArray, 2);
     }
 
-
     /// @notice Tests adding and removing attesters from the registry.
     function test_AddRemoveAttester() public {
         address attester = address(0x456);

--- a/test/foundry/unit/concrete/factory/TestRegistryFactory_Deployments.tree
+++ b/test/foundry/unit/concrete/factory/TestRegistryFactory_Deployments.tree
@@ -3,7 +3,8 @@ TestRegistryFactory_Deployments
     ├── when the constructor is called
     │   ├── it should set the implementation address correctly
     │   ├── it should revert if the owner address is zero
-    │   └── it should revert if the implementation address is zero
+    │   ├── it should revert if the implementation address is zero
+    │   └── it should revert if the threshold exceeds the length of attesters
     ├── when managing the attesters
     │   ├── it should add an attester
     │   ├── it should add multiple attesters

--- a/test/foundry/unit/concrete/modulemanager/TestModuleManager_UninstallModule.t.sol
+++ b/test/foundry/unit/concrete/modulemanager/TestModuleManager_UninstallModule.t.sol
@@ -164,7 +164,7 @@ contract TestModuleManager_UninstallModule is TestModuleManagement_Base {
             abi.encode(prev, "")
         );
 
-        bytes memory expectedRevertReason = abi.encodeWithSignature("CannotRemoveLastValidator()");
+        bytes memory expectedRevertReason = abi.encodeWithSignature("MissingValidator()");
 
         Execution[] memory execution = new Execution[](1);
         execution[0] = Execution(address(BOB_ACCOUNT), 0, callData);
@@ -205,7 +205,7 @@ contract TestModuleManager_UninstallModule is TestModuleManagement_Base {
         );
 
         // Define expected revert reason
-        bytes memory expectedRevertReason = abi.encodeWithSignature("MismatchModuleTypeId(uint256)", MODULE_TYPE_EXECUTOR);
+        bytes memory expectedRevertReason = abi.encodeWithSelector(ModuleNotInstalled.selector, MODULE_TYPE_EXECUTOR, address(VALIDATOR_MODULE));
 
         Execution[] memory execution = new Execution[](1);
         execution[0] = Execution(address(BOB_ACCOUNT), 0, callData);
@@ -392,7 +392,7 @@ contract TestModuleManager_UninstallModule is TestModuleManagement_Base {
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
 
         // Define expected revert reason
-        bytes memory expectedRevertReason = abi.encodeWithSignature("CannotRemoveLastValidator()");
+        bytes memory expectedRevertReason = abi.encodeWithSignature("MissingValidator()");
 
         // Expect the UserOperationRevertReason event
         vm.expectEmit(true, true, true, true);

--- a/test/foundry/unit/concrete/modulemanager/TestModuleManager_UninstallModule.t.sol
+++ b/test/foundry/unit/concrete/modulemanager/TestModuleManager_UninstallModule.t.sol
@@ -164,7 +164,7 @@ contract TestModuleManager_UninstallModule is TestModuleManagement_Base {
             abi.encode(prev, "")
         );
 
-        bytes memory expectedRevertReason = abi.encodeWithSignature("MissingValidator()");
+        bytes memory expectedRevertReason = abi.encodeWithSignature("CanNotRemoveLastValidator()");
 
         Execution[] memory execution = new Execution[](1);
         execution[0] = Execution(address(BOB_ACCOUNT), 0, callData);
@@ -392,7 +392,7 @@ contract TestModuleManager_UninstallModule is TestModuleManagement_Base {
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
 
         // Define expected revert reason
-        bytes memory expectedRevertReason = abi.encodeWithSignature("MissingValidator()");
+        bytes memory expectedRevertReason = abi.encodeWithSignature("CanNotRemoveLastValidator()");
 
         // Expect the UserOperationRevertReason event
         vm.expectEmit(true, true, true, true);

--- a/test/foundry/unit/concrete/modulemanager/TestModuleManager_UninstallModule.tree
+++ b/test/foundry/unit/concrete/modulemanager/TestModuleManager_UninstallModule.tree
@@ -10,13 +10,13 @@ TestModuleManager_UninstallModule
 ├── when uninstalling an executor module successfully
 │   └── it should uninstall the executor module
 ├── when uninstalling the last validator module
-│   └── it should revert with CannotRemoveLastValidator error
+│   └── it should revert with MissingValidator error
 ├── when uninstalling a module with incorrect module type
 │   └── it should revert with MismatchModuleTypeId error
 ├── when uninstalling a module that is not installed
 │   └── it should revert with ModuleNotInstalled error
 ├── when uninstalling the last validator module
-│   └── it should revert with CannotRemoveLastValidator error
+│   └── it should revert with MissingValidator error
 ├── when uninstalling the fallback handler module successfully
 │   └── it should uninstall the fallback handler module
 ├── when uninstalling a fallback handler that is not installed

--- a/test/foundry/unit/concrete/modulemanager/TestModuleManager_UninstallModule.tree
+++ b/test/foundry/unit/concrete/modulemanager/TestModuleManager_UninstallModule.tree
@@ -10,13 +10,13 @@ TestModuleManager_UninstallModule
 ├── when uninstalling an executor module successfully
 │   └── it should uninstall the executor module
 ├── when uninstalling the last validator module
-│   └── it should revert with MissingValidator error
+│   └── it should revert with CanNotRemoveLastValidator error
 ├── when uninstalling a module with incorrect module type
 │   └── it should revert with MismatchModuleTypeId error
 ├── when uninstalling a module that is not installed
 │   └── it should revert with ModuleNotInstalled error
 ├── when uninstalling the last validator module
-│   └── it should revert with MissingValidator error
+│   └── it should revert with CanNotRemoveLastValidator error
 ├── when uninstalling the fallback handler module successfully
 │   └── it should uninstall the fallback handler module
 ├── when uninstalling a fallback handler that is not installed

--- a/test/foundry/unit/fuzz/TestFuzz_ModuleManager.t.sol
+++ b/test/foundry/unit/fuzz/TestFuzz_ModuleManager.t.sol
@@ -314,7 +314,7 @@ contract TestFuzz_ModuleManager is TestModuleManagement_Base {
 
         // If the module type does not match the installation, expect a revert
         if (!IModule(moduleAddress).isModuleType(moduleTypeId)) {
-            bytes memory expectedRevertReason = abi.encodeWithSignature("MismatchModuleTypeId(uint256)", moduleTypeId);
+            bytes memory expectedRevertReason = abi.encodeWithSelector(ModuleNotInstalled.selector, moduleTypeId, moduleAddress);
             bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
             vm.expectEmit(true, true, true, true);
             emit UserOperationRevertReason(

--- a/test/foundry/utils/EventsAndErrors.sol
+++ b/test/foundry/utils/EventsAndErrors.sol
@@ -42,6 +42,8 @@ contract EventsAndErrors {
     error InnerCallFailed();
     error CallToDeployWithFactoryFailed();
     error NexusInitializationFailed();
+    error InvalidThreshold(uint8 providedThreshold, uint256 attestersCount);
+
 
     // ==========================
     // Operation Errors
@@ -61,7 +63,7 @@ contract EventsAndErrors {
     // ==========================
     // Module Errors
     // ==========================
-    error CannotRemoveLastValidator();
+    error MissingValidator();
     error InvalidModule(address module);
     error InvalidModuleTypeId(uint256 moduleTypeId);
     error ModuleAlreadyInstalled(uint256 moduleTypeId, address module);

--- a/test/foundry/utils/EventsAndErrors.sol
+++ b/test/foundry/utils/EventsAndErrors.sol
@@ -64,7 +64,6 @@ contract EventsAndErrors {
     // ==========================
     // Module Errors
     // ==========================
-    error MissingValidator();
     error CanNotRemoveLastValidator();
     error InvalidModule(address module);
     error InvalidModuleTypeId(uint256 moduleTypeId);

--- a/test/foundry/utils/EventsAndErrors.sol
+++ b/test/foundry/utils/EventsAndErrors.sol
@@ -64,6 +64,7 @@ contract EventsAndErrors {
     // Module Errors
     // ==========================
     error MissingValidator();
+    error CanNotRemoveLastValidator();
     error InvalidModule(address module);
     error InvalidModuleTypeId(uint256 moduleTypeId);
     error ModuleAlreadyInstalled(uint256 moduleTypeId, address module);

--- a/test/hardhat/smart-account/Nexus.ModuleManager.specs.ts
+++ b/test/hardhat/smart-account/Nexus.ModuleManager.specs.ts
@@ -183,7 +183,7 @@ describe("Nexus Module Management Tests", () => {
         ),
       ).to.be.revertedWithCustomError(
         deployedNexus,
-        "CannotRemoveLastValidator()",
+        "MissingValidator()",
       );
     });
 

--- a/test/hardhat/smart-account/Nexus.ModuleManager.specs.ts
+++ b/test/hardhat/smart-account/Nexus.ModuleManager.specs.ts
@@ -183,7 +183,7 @@ describe("Nexus Module Management Tests", () => {
         ),
       ).to.be.revertedWithCustomError(
         deployedNexus,
-        "MissingValidator()",
+        "CanNotRemoveLastValidator()",
       );
     });
 


### PR DESCRIPTION

- **# 25: Gas Optimization in `K1Validator.validateUserOp`**  
  Swapped `isValidSignatureNow` with `isValidSignatureNowCalldata` to reduce gas costs.  
  [Link](https://cantina.xyz/code/d1d4b139-9705-4367-9468-297b7078674e/findings/25)

- **# 26: Unnecessary Module Type Check on Uninstall**  
  Removed redundant type checks during module uninstall to streamline the process.  
  [Link](https://cantina.xyz/code/d1d4b139-9705-4367-9468-297b7078674e/findings/26)

- **# 24: Registry Threshold Validation**  
  Added checks to ensure the threshold doesn’t exceed the number of attesters.  
  [Link](https://cantina.xyz/code/d1d4b139-9705-4367-9468-297b7078674e/findings/24)

- **# 15: Validator Installation Check in `initializeAccount`**  
  Ensured at least one validator is installed during account initialization to avoid issues.  
  [Link](https://cantina.xyz/code/d1d4b139-9705-4367-9468-297b7078674e/findings/15)

- **# 14: Optimized `_uninstallValidator` Flow**  
  Modified the logic to check for an empty validator list *after* removal, improving efficiency.  
  [Link](https://cantina.xyz/code/d1d4b139-9705-4367-9468-297b7078674e/findings/14)

- **# 10: Documentation and Typo Fixes**  
  Cleared up various typos and improved doc clarity across the codebase.  
  [Link](https://cantina.xyz/code/d1d4b139-9705-4367-9468-297b7078674e/findings/10)

- **# 7: ModuleType Range Validation**  
  Added a range check for `ModuleType` to ensure it stays within valid bounds.  
  [Link](https://cantina.xyz/code/d1d4b139-9705-4367-9468-297b7078674e/findings/7)

- **# 50: Risk of Account Becoming Unrecoverable**  
  Discussed scenarios where an account could become unrecoverable if all validators are removed. Explored potential solutions like fallback validators or social recovery mechanisms.  
  [Link](https://cantina.xyz/code/d1d4b139-9705-4367-9468-297b7078674e/findings/50)

- **# 40: Missing Memory-Safe Assembly Annotation**  
  Added missing `memory-safe` annotations to assembly blocks where applicable.  
  [Link](https://cantina.xyz/code/d1d4b139-9705-4367-9468-297b7078674e/findings/40)

- **# 11: Custom `userOp.signature` Encoding Documentation**  
  Documented the custom encoding used for `userOp.signature` in enableMode.  
  [Link](https://cantina.xyz/code/d1d4b139-9705-4367-9468-297b7078674e/findings/11)

- **# 5: Missing Owner Address Validation in `K1ValidatorFactory`**  
  Added a check to ensure the factory owner address is non-zero for consistency with other factories.  
  [Link](https://cantina.xyz/code/d1d4b139-9705-4367-9468-297b7078674e/findings/5)

- **# 4: Missing Return Parameters in NatSpec**  
  Added descriptions for missing return parameters in NatSpec comments to improve code documentation.  
  [Link](https://cantina.xyz/code/d1d4b139-9705-4367-9468-297b7078674e/findings/4)

- **# 3: RegistryFactory `createAccount` Assumes `Bootstrap.initNexus` Will Be Used**  
  Documented that `RegistryFactory.createAccount` is only compatible with an inner `Bootstrap.initNexus` call as its initialization method.  
  [Link](https://cantina.xyz/code/d1d4b139-9705-4367-9468-297b7078674e/findings/3)

---