### PR TITLE
fix: check if hook installed before emergency uninstall

### DIFF
--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -46,6 +46,9 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
     /// @dev The event emitted when an emergency hook uninstallation is initiated.
     event EmergencyHookUninstallRequest(address hook, uint256 timestamp);
 
+    /// @dev The event emitted when an emergency hook uninstallation request is reset.
+    event EmergencyHookUninstallRequestReset(address hook, uint256 timestamp);
+
     /// @notice Initializes the smart account with the specified entry point.
     constructor(address anEntryPoint) {
         require(address(anEntryPoint) != address(0), EntryPointCanNotBeZero());
@@ -190,7 +193,7 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
         } else if (block.timestamp >= hookTimelock + 3 * _EMERGENCY_TIMELOCK) {
             // if the timelock has been left for too long, reset it
             accountStorage.emergencyUninstallTimelock[hook] = block.timestamp;
-            emit EmergencyHookUninstallRequest(hook, block.timestamp);
+            emit EmergencyHookUninstallRequestReset(hook, block.timestamp);
         } else if (block.timestamp >= hookTimelock + _EMERGENCY_TIMELOCK) {
             // if the timelock expired, clear it and uninstall the hook
             accountStorage.emergencyUninstallTimelock[hook] = 0;

--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -179,6 +179,7 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
     }
 
     function emergencyUninstallHook(address hook, bytes calldata deInitData) external payable onlyEntryPoint {
+        require(_isModuleInstalled(MODULE_TYPE_HOOK, hook, deInitData), ModuleNotInstalled(MODULE_TYPE_HOOK, hook));
         AccountStorage storage accountStorage = _getAccountStorage();
         uint256 hookTimelock = accountStorage.emergencyUninstallTimelock[hook];
 

--- a/test/foundry/unit/concrete/hook/TestNexus_Hook_Emergency_Uninstall.sol
+++ b/test/foundry/unit/concrete/hook/TestNexus_Hook_Emergency_Uninstall.sol
@@ -150,14 +150,65 @@ contract TestNexus_Hook_Emergency_Uninstall is TestModuleManagement_Base {
         newUserOps[0].callData = emergencyUninstallCalldata;
         bytes32 newUserOpHash = ENTRYPOINT.getUserOpHash(newUserOps[0]);
         newUserOps[0].signature = signMessage(BOB, newUserOpHash);
-
-        bytes memory expectedRevertReason = abi.encodeWithSelector(EmergencyTimeLockNotExpired.selector);
         // Expect the UserOperationRevertReason event
         vm.expectEmit(true, true, true, true);
         emit ModuleUninstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE));
         ENTRYPOINT.handleOps(newUserOps, payable(BOB.addr));
 
         assertFalse(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""), "Hook module should not be installed anymore");
+    }
+
+    function test_EmergencyUninstallHook_Success_Reset_SuperLongAfterInitiated() public {
+        // 1. Install the hook
+
+        // Ensure the hook module is not installed initially
+        assertFalse(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""), "Hook module should not be installed initially");
+
+        // Prepare call data for installing the hook module
+        bytes memory callData = abi.encodeWithSelector(IModuleManager.installModule.selector, MODULE_TYPE_HOOK, address(HOOK_MODULE), "");
+
+        // Install the hook module
+        installModule(callData, MODULE_TYPE_HOOK, address(HOOK_MODULE), EXECTYPE_DEFAULT);
+
+        // Assert that the hook module is now installed
+        assertTrue(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""), "Hook module should be installed");
+
+        uint256 prevTimeStamp = block.timestamp;
+
+
+
+        // 2. Request to uninstall the hook
+        bytes memory emergencyUninstallCalldata = abi.encodeWithSelector(Nexus.emergencyUninstallHook.selector, address(HOOK_MODULE), "");
+
+        // Initialize the userOps array with one operation
+        PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
+        userOps[0] = buildPackedUserOp(address(BOB_ACCOUNT), getNonce(address(BOB_ACCOUNT), MODE_VALIDATION, address(VALIDATOR_MODULE)));
+        userOps[0].callData = emergencyUninstallCalldata;
+        bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
+        userOps[0].signature = signMessage(BOB, userOpHash);
+
+        vm.expectEmit(true, true, true, true);
+        emit EmergencyHookUninstallRequest(address(HOOK_MODULE), block.timestamp);
+
+        ENTRYPOINT.handleOps(userOps, payable(BOB.addr));
+
+
+        // 3. Wait for time to pass
+        // more than 3 days
+        vm.warp(prevTimeStamp + 4 days);
+
+        PackedUserOperation[] memory newUserOps = new PackedUserOperation[](1);
+        newUserOps[0] = buildPackedUserOp(address(BOB_ACCOUNT), getNonce(address(BOB_ACCOUNT), MODE_VALIDATION, address(VALIDATOR_MODULE)));
+        newUserOps[0].callData = emergencyUninstallCalldata;
+        bytes32 newUserOpHash = ENTRYPOINT.getUserOpHash(newUserOps[0]);
+        newUserOps[0].signature = signMessage(BOB, newUserOpHash);
+
+        // Expect the UserOperationRevertReason event
+        vm.expectEmit(true, true, true, true);
+        emit EmergencyHookUninstallRequestReset(address(HOOK_MODULE), block.timestamp);
+        ENTRYPOINT.handleOps(newUserOps, payable(BOB.addr));
+
+        assertTrue(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""), "Hook module should still be installed");
     }
 
 }

--- a/test/foundry/utils/EventsAndErrors.sol
+++ b/test/foundry/utils/EventsAndErrors.sol
@@ -18,6 +18,7 @@ contract EventsAndErrors {
     event TryExecuteUnsuccessful(bytes callData, bytes result);
     event TryDelegateCallUnsuccessful(bytes callData, bytes result);
     event EmergencyHookUninstallRequest(address hook, uint256 timestamp);
+    event EmergencyHookUninstallRequestReset(address hook, uint256 timestamp);
 
     // ==========================
     // General Errors


### PR DESCRIPTION
**Problem:**

The emergencyUninstallHook() function is meant to allow the account owner to remove a hook from the account (minus the pre and post checks on the hook).

It is an alternate to the uninstallModule() function which offers hook checks on calls to uninstall any type of modules.

A timelock has been placed to only allow the account to emergency-uninstall the hook after 1 day of placing an uninstall request. But emergencyUninstallHook() fails to check that the hook was actually installed.


This allows the timelock to be bypassed through the following steps :

Call emergencyUninstallHook() to place an uninstall request even before installing the hook => this records a timestamp corresponding to the hook address
After nearly a day has passed, install the hook and use it
Immediately call emergencyUninstallHook() to utilize the request that was placed before
As only a day has passed, the call will go through
The timelock has been effectively bypassed by the account


**Solution:**

UninstallModule() on Nexus.sol checks that the module they are trying to uninstall through the call is actually installed. Add the same check to emergencyUninstallHook()


Also replaced the event EmergencyHookUninstallRequest in reset case with EmergencyHookUninstallRequestReset (Cantina 59)