### PR TITLE
refactor: remove duplicate modifier

### DIFF
--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -149,7 +149,8 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
     /// @param module The address of the module to install.
     /// @param initData Initialization data for the module.
     /// @dev This function can only be called by the EntryPoint or the account itself for security reasons.
-    function installModule(uint256 moduleTypeId, address module, bytes calldata initData) external payable onlyEntryPointOrSelf withHook {
+    /// @dev This function goes through hook checks via withHook modifier through internal function _installModule.
+    function installModule(uint256 moduleTypeId, address module, bytes calldata initData) external payable onlyEntryPointOrSelf {
         _installModule(moduleTypeId, module, initData);
         emit ModuleInstalled(moduleTypeId, module);
     }


### PR DESCRIPTION
The hook is called multiple times when the external installModule function is called.

**Fix:**

The internal function requires the modifier as _installModule is called from more than one places.

Remove from the external function with a natspec comment explaining that the modifier is applied to the internal function. Include a second natspec comment on the internal function to indicate that it should not be removed.