### PR TITLE
Fix/cantina 62

### DIFF
--- a/contracts/base/BaseAccount.sol
+++ b/contracts/base/BaseAccount.sol
@@ -13,8 +13,6 @@ pragma solidity ^0.8.27;
 // Learn more at https://biconomy.io. To report security issues, please contact us at: security@biconomy.io
 
 import { IEntryPoint } from "account-abstraction/contracts/interfaces/IEntryPoint.sol";
-
-import { Storage } from "./Storage.sol";
 import { IBaseAccount } from "../interfaces/base/IBaseAccount.sol";
 
 /// @title Nexus - BaseAccount

--- a/contracts/base/BaseAccount.sol
+++ b/contracts/base/BaseAccount.sol
@@ -25,9 +25,13 @@ import { IBaseAccount } from "../interfaces/base/IBaseAccount.sol";
 /// @author @filmakarov | Biconomy | filipp.makarov@biconomy.io
 /// @author @zeroknots | Rhinestone.wtf | zeroknots.eth
 /// Special thanks to the Solady team for foundational contributions: https://github.com/Vectorized/solady
-contract BaseAccount is Storage, IBaseAccount {
+contract BaseAccount is IBaseAccount {
     /// @notice Identifier for this implementation on the network
     string internal constant _ACCOUNT_IMPLEMENTATION_ID = "biconomy.nexus.1.0.0-beta";
+
+    /// @notice The canonical address for the ERC4337 EntryPoint contract, version 0.7.
+    /// This address is consistent across all supported networks.
+    address internal immutable _ENTRYPOINT;
 
     /// @dev Ensures the caller is either the EntryPoint or this account itself.
     /// Reverts with AccountAccessUnauthorized if the check fails.

--- a/contracts/base/Storage.sol
+++ b/contracts/base/Storage.sol
@@ -27,10 +27,6 @@ contract Storage is IStorage {
     /// ERC-7201 namespaced via `keccak256(abi.encode(uint256(keccak256(bytes("biconomy.storage.Nexus"))) - 1)) & ~bytes32(uint256(0xff));`
     bytes32 private constant _STORAGE_LOCATION = 0x0bb70095b32b9671358306b0339b4c06e7cbd8cb82505941fba30d1eb5b82f00;
 
-    /// @notice The canonical address for the ERC4337 EntryPoint contract, version 0.7.
-    /// This address is consistent across all supported networks.
-    address internal immutable _ENTRYPOINT;
-
     /// @dev Utilizes ERC-7201's namespaced storage pattern for isolated storage access. This method computes
     /// the storage slot based on a predetermined location, ensuring collision-resistant storage for contract states.
     /// @custom:storage-location ERC-7201 formula applied to "biconomy.storage.Nexus", facilitating unique


### PR DESCRIPTION
Storage contract defines all storage variables to be used within the nexus smart account.

Nexus inherits from ModuleManager and BaseAccount, and both of them inherit from this storage contract. This creates a convoluted inheritance pattern.

BaseAccount/ ModuleManager is not intended to be used separately and thus only one of these needs inheritance from storage, for the nexus account to be able to access it.

**FIX**

Remove Storage contract from the inheritance declaration of BaseAccount contract
Move _ENTRYPOINT var to BaseAccount.
it's doable now cause ModuleManager now doesn't have any modifier that requires _ENTRYPOINT.