### PR TITLE
TSTORE validator to use it for _checkRegistry (PoC)

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -4,7 +4,7 @@
   auto_detect_solc = false
   block_timestamp = 1_680_220_800 # March 31, 2023 at 00:00 GMT
   bytecode_hash = "none"
-  evm_version = "paris"           # See https://www.evmdiff.com/features?name=PUSH0&kind=opcode
+  evm_version = "cancun"           # See https://www.evmdiff.com/features?name=PUSH0&kind=opcode
   fuzz = { runs = 1_000 }
   via-ir = false
   gas_reports = ["*"]


### PR DESCRIPTION
To solve [the issue with checking validator with registry](https://cantina.xyz/code/d1d4b139-9705-4367-9468-297b7078674e/findings/23) not only on installation but on every userOp, we can pass the validator from `validateUserOp` to `execute` and other functions via tstore/tload


They are supported by most EVMs: https://www.evmdiff.com/features?feature=opcodes#TLOAD