### PR TITLE
Sig malleability protection for erc1271 only

### DIFF
--- a/contracts/modules/validators/K1Validator.sol
+++ b/contracts/modules/validators/K1Validator.sol
@@ -109,6 +109,11 @@ contract K1Validator is IValidator, ERC7739Validator {
         _safeSenders.remove(msg.sender, sender);
     }
 
+    /// @notice Checks if a sender is in the _safeSenders list for the smart account
+    function isSafeSender(address sender, address smartAccount) external view returns (bool) {
+        return _safeSenders.contains(smartAccount, sender);
+    }
+
     /**
      * Check if the module is initialized
      * @param smartAccount The smart account to check

--- a/test/foundry/unit/concrete/modules/TestK1Validator.t.sol
+++ b/test/foundry/unit/concrete/modules/TestK1Validator.t.sol
@@ -232,21 +232,35 @@ contract TestK1Validator is NexusTest_Base {
         assertEq(res, VALIDATION_SUCCESS, "Valid signature should be accepted");
     }
 
-    /// @notice Tests that a signature with an invalid 's' value is rejected
-    function test_ValidateUserOp_InvalidSValue() public {
-        bytes32 originalHash = keccak256(abi.encodePacked("invalid message"));
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(BOB.privateKey, originalHash);
+    /// @notice Tests signature malleability is prevented by nonce in the 4337 flow
+    function test_ValidateUserOp_Inverted_S_Value_Fails_because_of_nonce() public {
+        Counter counter = new Counter();
+        //build and sign a userOp
+        Execution[] memory execution = new Execution[](1);
+        execution[0] = Execution(address(counter), 0, abi.encodeWithSelector(Counter.incrementNumber.selector));
+        PackedUserOperation[] memory userOps = buildPackedUserOperation(BOB, BOB_ACCOUNT, EXECTYPE_DEFAULT, execution, address(VALIDATOR_MODULE), 0);
+        ENTRYPOINT.handleOps(userOps, payable(BOB.addr));
 
-        // Ensure 's' is in the upper range (invalid)
-        if (uint256(s) <= 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) {
-            s = bytes32(0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A1); // Set an invalid 's' value
+        // parse the userOp.signature via assembly
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        assembly {
+            r := mload(add(userOps, 0x20))
+            s := mload(add(userOps, 0x40))
+            v := byte(0, mload(add(userOps, 0x60)))
         }
 
-        userOp.signature = abi.encodePacked(r, s, v);
+        // invert signature
+        bytes32 s1;
+        if (uint256(s) <= 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) {
+            s1 = bytes32(115792089237316195423570985008687907852837564279074904382605163141518161494337 - uint256(s));
+        }
+        userOps[0].signature = abi.encodePacked(r, s1, v == 27 ? 28 : v);
 
-        uint256 res = validator.validateUserOp(userOp, originalHash);
-
-        assertEq(res, VALIDATION_FAILED, "Signature with invalid 's' value should be rejected");
+        bytes memory revertReason = abi.encodeWithSelector(FailedOp.selector, 0, "AA25 invalid account nonce");
+        vm.expectRevert(revertReason);
+        ENTRYPOINT.handleOps(userOps, payable(BOB.addr));
     }
 
     /// @notice Tests that a valid signature with a valid 's' value is accepted for isValidSignatureWithSender
@@ -272,20 +286,29 @@ contract TestK1Validator is NexusTest_Base {
     }
 
     /// @notice Tests that a signature with an invalid 's' value is rejected for isValidSignatureWithSender
-    function test_IsValidSignatureWithSender_InvalidSValue() public {
+    function test_IsValidSignatureWithSender_Inverted_S_Value_Fails() public {
+        // allow vanilla 1271 flow
+        vm.prank(address(BOB_ACCOUNT));
+        validator.addSafeSender(address(this));
+        
         bytes32 originalHash = keccak256(abi.encodePacked("invalid message"));
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(BOB.privateKey, originalHash);
+        bytes32 s1;
 
         // Ensure 's' is in the upper range (invalid)
         if (uint256(s) <= 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) {
-            s = bytes32(0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A1); // Set an invalid 's' value
+            s1 = bytes32(115792089237316195423570985008687907852837564279074904382605163141518161494337 - uint256(s));
         }
-
+        // assert original signature is valid
         bytes memory signedMessage = abi.encodePacked(r, s, v);
-        bytes memory completeSignature = abi.encodePacked(address(validator), signedMessage);
+        vm.prank(address(BOB_ACCOUNT));
+        bytes4 result = validator.isValidSignatureWithSender(address(this), originalHash, signedMessage);
+        assertEq(result, ERC1271_MAGICVALUE, "Valid signature should be accepted");
 
-        bytes4 result = BOB_ACCOUNT.isValidSignature(originalHash, completeSignature);
-
+        // invert signature
+        signedMessage = abi.encodePacked(r, s1, v == 27 ? 28 : v);
+        vm.prank(address(BOB_ACCOUNT));
+        result = validator.isValidSignatureWithSender(address(this), originalHash, signedMessage);
         assertEq(result, ERC1271_INVALID, "Signature with invalid 's' value should be rejected");
     }
 

--- a/test/foundry/unit/concrete/modules/TestK1Validator.t.sol
+++ b/test/foundry/unit/concrete/modules/TestK1Validator.t.sol
@@ -367,6 +367,14 @@ contract TestK1Validator is NexusTest_Base {
         assertTrue(validator.isSafeSender(address(0x02), address(0x03)));
     }
 
+    /// @notice Tests the isSafeSender function to check if a sender is in the safe senders list
+    function test_isSafeSender_Success() public {
+        assertFalse(validator.isSafeSender(address(0x01), address(0x03)));
+        prank(address(0x03));
+        validator.addSafeSender(address(0x01));
+        assertTrue(validator.isSafeSender(address(0x01), address(0x03)));
+    }
+
     /// @notice Generates an ERC-1271 hash for personal sign
     /// @param childHash The child hash
     /// @return The ERC-1271 hash for personal sign

--- a/test/foundry/unit/concrete/modules/TestK1Validator.t.sol
+++ b/test/foundry/unit/concrete/modules/TestK1Validator.t.sol
@@ -345,6 +345,28 @@ contract TestK1Validator is NexusTest_Base {
         assertEq(mockSafe1271Caller.balanceOf(address(BOB_ACCOUNT)), 1);
     }
 
+    /// @notice Tests the addSafeSender function to add a safe sender to the safe senders list
+    function test_addSafeSender_Success() public {
+        prank(address(BOB_ACCOUNT));
+        validator.addSafeSender(address(mockSafe1271Caller));
+        assertTrue(validator.isSafeSender(address(mockSafe1271Caller), address(BOB_ACCOUNT)), "MockSafe1271Caller should be in the safe senders list");
+    }
+
+    /// @notice Tests the removeSafeSender function to remove a safe sender from the safe senders list
+    function test_removeSafeSender_Success() public {
+        prank(address(BOB_ACCOUNT));
+        validator.removeSafeSender(address(mockSafe1271Caller));
+        assertFalse(validator.isSafeSender(address(mockSafe1271Caller), address(BOB_ACCOUNT)), "MockSafe1271Caller should be removed from the safe senders list");
+    }
+
+    /// @notice Tests the fillSafeSenders function to fill the safe senders list
+    function test_fillSafeSenders_Success() public {
+        prank(address(0x03));
+        validator.onInstall(abi.encodePacked(address(0xdecaf0), address(0x01), address(0x02)));
+        assertTrue(validator.isSafeSender(address(0x01), address(0x03)));
+        assertTrue(validator.isSafeSender(address(0x02), address(0x03)));
+    }
+
     /// @notice Generates an ERC-1271 hash for personal sign
     /// @param childHash The child hash
     /// @return The ERC-1271 hash for personal sign

--- a/test/foundry/unit/concrete/modules/TestK1Validator.tree
+++ b/test/foundry/unit/concrete/modules/TestK1Validator.tree
@@ -11,11 +11,12 @@ TestK1Validator
 ├── when testing the validateUserOp function
 │   ├── it should succeed with a valid signature (toEthSignedMessageHash)
 │   └── it should fail with an invalid signature
+│   └── signature malleability should be rejected because of nonce
 ├── when testing the isValidSignatureWithSender function
 │   ├── it should succeed with a valid signature
 │   └── it should fail with an invalid signature
 │   └── it should succeed with a valid signature for isValidSignatureWithSender
-│   └── it should fail with an invalid 's' value for isValidSignatureWithSender
+│   └── it should fail with an inverted 's' value for isValidSignatureWithSender
 ├── when testing the transferOwnership function
 │   ├── it should transfer ownership to a new address
 │   └── it should revert when transferring to the zero address
@@ -27,3 +28,11 @@ TestK1Validator
 └── when testing the isModuleType function
     ├── it should return true for VALIDATOR module type
     └── it should return false for an invalid module type
+├── when testing the addSafeSender function
+│   └── it should add a safe sender to the safe senders list
+├── when testing the removeSafeSender function
+│   └── it should remove a safe sender from the safe senders list
+├── when testing the fillSafeSenders function
+│   └── it should fill the safe senders list
+├── when testing the isSafeSender function
+│   └── it should check if a sender is in the safe senders list


### PR DESCRIPTION
Moved sig malleability protection to 1271 flow only as for erc4337 it is excess

1) ERC-4337 flow has nonce protection against replays including signature malleability. So there is no need to apply this check

2) ERC-1271 flow has no in-built protection against replays including signature malleability. 
Even reference implementation includes the 's' check: https://eips.ethereum.org/EIPS/eip-1271#reference-implementation

If one is using OZ's ECDSA, this above check is applied under the hood : https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/ECDSA.sol#L134-L145
However, in our K1Validator we use Solady ECDSA.tryRecover 
https://github.com/bcnmy/nexus/blob/69f437bb5db46e60c62bb780fcebc4120cab130a/contracts/modules/validators/K1Validator.sol#L15
https://github.com/Vectorized/solady/blob/45bba1221ad451289d2f54c2f7f48aea624e17aa/src/utils/ECDSA.sol#L218-L259
which, as far I can see, doesn't have such a check

Of course disallowing using n - s is not considered to be the full replay protection. However, we can not know if any additional protection is incorporated into the signed hash in 1271, at the same time we can not enforce stronger replay protection such as nonce, so we can at least protect from signature malleability and expect protocols which use 1271 to have their own replay protection (and if they decide to use full bytes signature as protection, they are covered from malleability).
