### PR TITLE
Revert to last audited commit (9f1c23f6)

### DIFF
--- a/contracts/lib/ExecLib.sol
+++ b/contracts/lib/ExecLib.sol
@@ -43,9 +43,6 @@ library ExecLib {
             // Extract the ERC7579 Executions
             executionBatch.offset := add(dataPointer, 32)
             executionBatch.length := calldataload(dataPointer)
-            if lt(callData.length, executionBatch.length) {
-                revert(0, 0)
-            }
         }
     }
 


### PR DESCRIPTION
As per communication with Spearbit it was decided to remove the check

1) Nor me neither auditors were able to figure out the PoC to exploit this
2) Solady doesn't have this check in their lib: [link](https://github.com/Vectorized/solady/blob/ceb1019a774a04c2ee1a283d3db5a3dfcb7ab8c2/src/accounts/LibERC7579.sol#L185-L199)
3) The check was inaccurate anyways (executions.length returns struct array length, not bytes array length) 