### PR TITLE
Remove dependency of tests on scripts

### DIFF
--- a/scripts/foundry/HelperConfig.s.sol
+++ b/scripts/foundry/HelperConfig.s.sol
@@ -9,7 +9,7 @@ import {Script} from "forge-std/Script.sol";
 
 contract HelperConfig is Script {
     IEntryPoint public ENTRYPOINT;
-    address private  constant MAINNET_ENTRYPOINT_ADDRESS = 0x0000000071727De22E5E9d8BAf0edAc6f37da032;
+    address private constant MAINNET_ENTRYPOINT_ADDRESS = 0x0000000071727De22E5E9d8BAf0edAc6f37da032;
 
     constructor() {
         if (block.chainid == 31337) {


### PR DESCRIPTION
Fix this https://github.com/bcnmy/nexus/issues/223

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the `TestHelper` contract to streamline the setup of the `ENTRYPOINT` address, replacing the instantiation of `HelperConfig` with a new `setupEntrypoint` function that handles both test and mainnet scenarios.

### Detailed summary
- Removed the import of `HelperConfig` in `TestHelper`.
- Added a `setupEntrypoint` function in `TestHelper` to initialize `ENTRYPOINT`.
- The `setupEntrypoint` function checks the `chainid` and sets `ENTRYPOINT` accordingly.
- The constant `MAINNET_ENTRYPOINT_ADDRESS` is defined in both `HelperConfig` and `TestHelper`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->