### PR TITLE
feat: add prevalidation hook support

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -31,7 +31,8 @@
     "reason-string": "error",
     "avoid-low-level-calls": "off",
     "no-inline-assembly": "off",
-    "no-complex-fallback": "off"
+    "no-complex-fallback": "off",
+    "gas-custom-errors": "off"
   },
   "plugins": ["prettier"]
 }

--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -119,7 +119,7 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
             validationData = IValidator(validator).validateUserOp(userOp, userOpHash);
         } else {
             if (_isValidatorInstalled(validator)) {
-                PackedUserOperation memory userOp;
+                PackedUserOperation memory userOp = op;
                 // If the validator is installed, forward the validation task to the validator
                 (userOpHash, userOp.signature) = _withPreValidationHook(userOpHash, op, missingAccountFunds);
                 validationData = IValidator(validator).validateUserOp(userOp, userOpHash);

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -396,7 +396,7 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
         // Mark nonce as used
         _getAccountStorage().nonces[data.nonce] = true;
         // Check if the signature is valid
-        require((IValidator(validator).isValidSignatureWithSender(msg.sender, hash, signature[20:]) == bytes4(0x1626ba7e)), EmergencyUninstallSigError());
+        require((IValidator(validator).isValidSignatureWithSender(address(this), hash, signature[20:]) == ERC1271_MAGICVALUE), EmergencyUninstallSigError());
     }
 
     /// @dev Retrieves the pre-validation hook from the storage based on the hook type.
@@ -434,7 +434,6 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
         uint256 missingAccountFunds
     )
         internal
-        view
         virtual
         returns (bytes32 postHash, bytes memory postSig)
     {
@@ -443,7 +442,7 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
         // If no pre-validation hook is installed, return the original hash and signature
         if (preValidationHook == address(0)) return (hash, userOp.signature);
         // Otherwise, call the pre-validation hook and return the updated hash and signature
-        else return IPreValidationHookERC4337(preValidationHook).preValidationHookERC4337(address(this), userOp, missingAccountFunds, hash);
+        else return IPreValidationHookERC4337(preValidationHook).preValidationHookERC4337(userOp, missingAccountFunds, hash);
     }
 
     /// @notice Checks if an enable mode signature is valid.

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -419,7 +419,7 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
         // If no pre-validation hook is installed, return the original hash and signature
         if (preValidationHook == address(0)) return (hash, signature);
         // Otherwise, call the pre-validation hook and return the updated hash and signature
-        else return IPreValidationHookERC1271(preValidationHook).preValidationHookERC1271(address(this), msg.sender, hash, signature);
+        else return IPreValidationHookERC1271(preValidationHook).preValidationHookERC1271(msg.sender, hash, signature);
     }
 
     /// @dev Calls the pre-validation hook for ERC-4337.

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -16,6 +16,7 @@ import { SentinelListLib } from "sentinellist/SentinelList.sol";
 import { Storage } from "./Storage.sol";
 import { IHook } from "../interfaces/modules/IHook.sol";
 import { IModule } from "../interfaces/modules/IModule.sol";
+import { IPreValidationHookERC1271, IPreValidationHookERC4337 } from "../interfaces/modules/IPreValidationHook.sol";
 import { IExecutor } from "../interfaces/modules/IExecutor.sol";
 import { IFallback } from "../interfaces/modules/IFallback.sol";
 import { IValidator } from "../interfaces/modules/IValidator.sol";
@@ -28,13 +29,18 @@ import {
     MODULE_TYPE_EXECUTOR,
     MODULE_TYPE_FALLBACK,
     MODULE_TYPE_HOOK,
+    MODULE_TYPE_PREVALIDATION_HOOK_ERC1271,
+    MODULE_TYPE_PREVALIDATION_HOOK_ERC4337,
     MODULE_TYPE_MULTI,
     MODULE_ENABLE_MODE_TYPE_HASH,
+    EMERGENCY_UNINSTALL_TYPE_HASH,
     ERC1271_MAGICVALUE
 } from "../types/Constants.sol";
 import { EIP712 } from "solady/utils/EIP712.sol";
 import { ExcessivelySafeCall } from "excessively-safe-call/ExcessivelySafeCall.sol";
+import { PackedUserOperation } from "account-abstraction/interfaces/PackedUserOperation.sol";
 import { RegistryAdapter } from "./RegistryAdapter.sol";
+import { EmergencyUninstall } from "../types/DataTypes.sol";
 
 /// @title Nexus - ModuleManager
 /// @notice Manages Validator, Executor, Hook, and Fallback modules within the Nexus suite, supporting
@@ -161,6 +167,8 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
             _installFallbackHandler(module, initData);
         } else if (moduleTypeId == MODULE_TYPE_HOOK) {
             _installHook(module, initData);
+        } else if (moduleTypeId == MODULE_TYPE_PREVALIDATION_HOOK_ERC1271 || moduleTypeId == MODULE_TYPE_PREVALIDATION_HOOK_ERC4337) {
+            _installPreValidationHook(moduleTypeId, module, initData);
         } else if (moduleTypeId == MODULE_TYPE_MULTI) {
             _multiTypeInstall(module, initData);
         } else {
@@ -225,9 +233,14 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
 
     /// @dev Uninstalls a hook module, ensuring the current hook matches the one intended for uninstallation.
     /// @param hook The address of the hook to be uninstalled.
+    /// @param hookType The type of the hook to be uninstalled.
     /// @param data De-initialization data to configure the hook upon uninstallation.
-    function _uninstallHook(address hook, bytes calldata data) internal virtual {
-        _setHook(address(0));
+    function _uninstallHook(address hook, uint256 hookType, bytes calldata data) internal virtual {
+        if (hookType == MODULE_TYPE_HOOK) {
+            _setHook(address(0));
+        } else if (hookType == MODULE_TYPE_PREVALIDATION_HOOK_ERC1271 || hookType == MODULE_TYPE_PREVALIDATION_HOOK_ERC4337) {
+            _uninstallPreValidationHook(hook, hookType, data);
+        }
         hook.excessivelySafeCall(gasleft(), 0, 0, abi.encodeWithSelector(IModule.onUninstall.selector, data));
     }
 
@@ -282,6 +295,93 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
         fallbackHandler.excessivelySafeCall(gasleft(), 0, 0, abi.encodeWithSelector(IModule.onUninstall.selector, data[4:]));
     }
 
+    /// @dev Installs a pre-validation hook module, ensuring no other pre-validation hooks are installed before proceeding.
+    /// @param preValidationHookType The type of the pre-validation hook.
+    /// @param preValidationHook The address of the pre-validation hook to be installed.
+    /// @param data Initialization data to configure the hook upon installation.
+    function _installPreValidationHook(
+        uint256 preValidationHookType,
+        address preValidationHook,
+        bytes calldata data
+    )
+        internal
+        virtual
+        withRegistry(preValidationHook, preValidationHookType)
+    {
+        if (!IModule(preValidationHook).isModuleType(preValidationHookType)) revert MismatchModuleTypeId(MODULE_TYPE_HOOK);
+        address currentPreValidationHook = _getPreValidationHook(preValidationHookType);
+        require(currentPreValidationHook == address(0), PrevalidationHookAlreadyInstalled(currentPreValidationHook));
+        _setPreValidationHook(preValidationHookType, preValidationHook);
+        IModule(preValidationHook).onInstall(data);
+    }
+
+    /// @dev Uninstalls a pre-validation hook module
+    /// @param preValidationHook The address of the pre-validation hook to be uninstalled.
+    /// @param hookType The type of the pre-validation hook.
+    /// @param data De-initialization data to configure the hook upon uninstallation.
+    function _uninstallPreValidationHook(address preValidationHook, uint256 hookType, bytes calldata data) internal virtual {
+        _setPreValidationHook(hookType, address(0));
+        preValidationHook.excessivelySafeCall(gasleft(), 0, 0, abi.encodeWithSelector(IModule.onUninstall.selector, data));
+    }
+
+    /// @dev Sets the current pre-validation hook in the storage to the specified address, based on the hook type.
+    /// @param hookType The type of the pre-validation hook.
+    /// @param hook The new hook address.
+    function _setPreValidationHook(uint256 hookType, address hook) internal virtual {
+        if (hookType == MODULE_TYPE_PREVALIDATION_HOOK_ERC1271) {
+            _getAccountStorage().preValidationHookERC1271 = IPreValidationHookERC1271(hook);
+        } else if (hookType == MODULE_TYPE_PREVALIDATION_HOOK_ERC4337) {
+            _getAccountStorage().preValidationHookERC4337 = IPreValidationHookERC4337(hook);
+        }
+    }
+
+    /// @dev Retrieves the pre-validation hook from the storage based on the hook type.
+    /// @param preValidationHookType The type of the pre-validation hook.
+    /// @return preValidationHook The address of the pre-validation hook.
+    function _getPreValidationHook(uint256 preValidationHookType) internal view returns (address preValidationHook) {
+        preValidationHook = preValidationHookType == MODULE_TYPE_PREVALIDATION_HOOK_ERC1271
+            ? address(_getAccountStorage().preValidationHookERC1271)
+            : address(_getAccountStorage().preValidationHookERC4337);
+    }
+
+    /// @dev Calls the pre-validation hook for ERC-1271.
+    /// @param hash The hash of the user operation.
+    /// @param signature The signature to validate.
+    /// @return postHash The updated hash after the pre-validation hook.
+    /// @return postSig The updated signature after the pre-validation hook.
+    function _withPreValidationHook(bytes32 hash, bytes calldata signature) internal view virtual returns (bytes32 postHash, bytes memory postSig) {
+        // Get the pre-validation hook for ERC-1271
+        address preValidationHook = _getPreValidationHook(MODULE_TYPE_PREVALIDATION_HOOK_ERC1271);
+        // If no pre-validation hook is installed, return the original hash and signature
+        if (preValidationHook == address(0)) return (hash, signature);
+        // Otherwise, call the pre-validation hook and return the updated hash and signature
+        else return IPreValidationHookERC1271(preValidationHook).preValidationHookERC1271(address(this), msg.sender, hash, signature);
+    }
+
+    /// @dev Calls the pre-validation hook for ERC-4337.
+    /// @param hash The hash of the user operation.
+    /// @param userOp The user operation data.
+    /// @param missingAccountFunds The amount of missing account funds.
+    /// @return postHash The updated hash after the pre-validation hook.
+    /// @return postSig The updated signature after the pre-validation hook.
+    function _withPreValidationHook(
+        bytes32 hash,
+        PackedUserOperation memory userOp,
+        uint256 missingAccountFunds
+    )
+        internal
+        view
+        virtual
+        returns (bytes32 postHash, bytes memory postSig)
+    {
+        // Get the pre-validation hook for ERC-4337
+        address preValidationHook = _getPreValidationHook(MODULE_TYPE_PREVALIDATION_HOOK_ERC4337);
+        // If no pre-validation hook is installed, return the original hash and signature
+        if (preValidationHook == address(0)) return (hash, userOp.signature);
+        // Otherwise, call the pre-validation hook and return the updated hash and signature
+        else return IPreValidationHookERC4337(preValidationHook).preValidationHookERC4337(address(this), userOp, missingAccountFunds, hash);
+    }
+
     /// @notice Installs a module with multiple types in a single operation.
     /// @dev This function handles installing a multi-type module by iterating through each type and initializing it.
     /// The initData should include an ABI-encoded tuple of (uint[] types, bytes[] initDatas).
@@ -321,6 +421,12 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
             else if (theType == MODULE_TYPE_HOOK) {
                 _installHook(module, initDatas[i]);
             }
+            /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+            /*          INSTALL PRE-VALIDATION HOOK                       */
+            /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+            else if (theType == MODULE_TYPE_PREVALIDATION_HOOK_ERC1271 || theType == MODULE_TYPE_PREVALIDATION_HOOK_ERC4337) {
+                _installPreValidationHook(theType, module, initDatas[i]);
+            }
         }
     }
 
@@ -345,6 +451,22 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
         }
     }
 
+    /// @notice Checks if an emergency uninstall signature is valid.
+    /// @param data The emergency uninstall data.
+    /// @param signature The signature to validate.
+    function _checkEmergencyUninstallSignature(EmergencyUninstall calldata data, bytes calldata signature) internal {
+        address validator = address(bytes20(signature[0:20]));
+        require(_isValidatorInstalled(validator), ValidatorNotInstalled(validator));
+        // Hash the data
+        bytes32 hash = _getEmergencyUninstallDataHash(data.hook, data.hookType, data.deInitData, data.nonce);
+        // Check if nonce is valid
+        require(!_getAccountStorage().nonces[data.nonce], InvalidNonce());
+        // Mark nonce as used
+        _getAccountStorage().nonces[data.nonce] = true;
+        // Check if the signature is valid
+        require((IValidator(validator).isValidSignatureWithSender(msg.sender, hash, signature[20:]) == bytes4(0x1626ba7e)), EmergencyUninstallSigError());
+    }
+
     /// @notice Builds the enable mode data hash as per eip712
     /// @param module Module being enabled
     /// @param moduleType Type of the module as per EIP-7579
@@ -353,6 +475,16 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
     /// @return structHash data hash
     function _getEnableModeDataHash(address module, uint256 moduleType, bytes32 userOpHash, bytes calldata initData) internal view returns (bytes32) {
         return keccak256(abi.encode(MODULE_ENABLE_MODE_TYPE_HASH, module, moduleType, userOpHash, keccak256(initData)));
+    }
+
+    /// @notice Builds the emergency uninstall data hash as per eip712
+    /// @param hookType Type of the hook (4 for Hook, 8 for ERC-1271 Prevalidation Hook, 9 for ERC-4337 Prevalidation Hook)
+    /// @param hook address of the hook being uninstalled
+    /// @param data De-initialization data to configure the hook upon uninstallation.
+    /// @param nonce Unique nonce for the operation
+    /// @return structHash data hash
+    function _getEmergencyUninstallDataHash(address hook, uint256 hookType, bytes calldata data, uint256 nonce) internal view returns (bytes32) {
+        return _hashTypedData(keccak256(abi.encode(EMERGENCY_UNINSTALL_TYPE_HASH, hook, hookType, keccak256(data), nonce)));
     }
 
     /// @notice Checks if a module is installed on the smart account.
@@ -376,6 +508,8 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
             return _isFallbackHandlerInstalled(selector, module);
         } else if (moduleTypeId == MODULE_TYPE_HOOK) {
             return _isHookInstalled(module);
+        } else if (moduleTypeId == MODULE_TYPE_PREVALIDATION_HOOK_ERC1271 || moduleTypeId == MODULE_TYPE_PREVALIDATION_HOOK_ERC4337) {
+            return _getPreValidationHook(moduleTypeId) == module;
         } else {
             return false;
         }

--- a/contracts/interfaces/base/IModuleManagerEventsAndErrors.sol
+++ b/contracts/interfaces/base/IModuleManagerEventsAndErrors.sol
@@ -66,6 +66,9 @@ interface IModuleManagerEventsAndErrors {
     /// @dev Thrown when there is an attempt to install a hook while another is already installed.
     error HookAlreadyInstalled(address currentHook);
 
+    /// @dev Thrown when there is an attempt to install a PreValidationHook while another is already installed.
+    error PrevalidationHookAlreadyInstalled(address currentPreValidationHook);
+
     /// @dev Thrown when there is an attempt to install a fallback handler for a selector already having one.
     error FallbackAlreadyInstalledForSelector(bytes4 selector);
 
@@ -83,6 +86,12 @@ interface IModuleManagerEventsAndErrors {
 
     /// @dev Thrown when unable to validate Module Enable Mode signature
     error EnableModeSigError();
+
+    /// @dev Thrown when unable to validate Emergency Uninstall signature
+    error EmergencyUninstallSigError();
+
+    /// @notice Error thrown when an invalid nonce is used
+    error InvalidNonce();
 
     /// Error thrown when account installs/uninstalls module with mismatched input `moduleTypeId`
     error MismatchModuleTypeId(uint256 moduleTypeId);

--- a/contracts/interfaces/base/IStorage.sol
+++ b/contracts/interfaces/base/IStorage.sol
@@ -13,7 +13,7 @@ pragma solidity ^0.8.27;
 // Learn more at https://biconomy.io. To report security issues, please contact us at: security@biconomy.io
 
 import { SentinelListLib } from "sentinellist/SentinelList.sol";
-
+import { IPreValidationHookERC1271, IPreValidationHookERC4337 } from "../modules/IPreValidationHook.sol";
 import { IHook } from "../modules/IHook.sol";
 import { CallType } from "../../lib/ModeLib.sol";
 
@@ -31,16 +31,29 @@ import { CallType } from "../../lib/ModeLib.sol";
 interface IStorage {
     /// @notice Struct storing validators and executors using Sentinel lists, and fallback handlers via mapping.
     struct AccountStorage {
-        SentinelListLib.SentinelList validators; ///< List of validators, initialized upon contract deployment.
-        SentinelListLib.SentinelList executors; ///< List of executors, similarly initialized.
-        mapping(bytes4 => FallbackHandler) fallbacks; ///< Mapping of selectors to their respective fallback handlers.
-        IHook hook; ///< Current hook module associated with this account.
-        mapping(address hook => uint256) emergencyUninstallTimelock; ///< Mapping of hooks to requested timelocks.
+        ///< List of validators, initialized upon contract deployment.
+        SentinelListLib.SentinelList validators;
+        ///< List of executors, similarly initialized.
+        SentinelListLib.SentinelList executors;
+        ///< Mapping of selectors to their respective fallback handlers.
+        mapping(bytes4 => FallbackHandler) fallbacks;
+        ///< Current hook module associated with this account.
+        IHook hook;
+        ///< Mapping of hooks to requested timelocks.
+        mapping(address hook => uint256) emergencyUninstallTimelock;
+        ///< PreValidation hook for validateUserOp
+        IPreValidationHookERC4337 preValidationHookERC4337;
+        ///< PreValidation hook for isValidSignature
+        IPreValidationHookERC1271 preValidationHookERC1271;
+        ///< Mapping of used nonces for replay protection.
+        mapping(uint256 => bool) nonces;
     }
 
     /// @notice Defines a fallback handler with an associated handler address and a call type.
     struct FallbackHandler {
-        address handler; ///< The address of the fallback function handler.
-        CallType calltype; ///< The type of call this handler supports (e.g., static or call).
+        ///< The address of the fallback function handler.
+        address handler;
+        ///< The type of call this handler supports (e.g., static or call).
+        CallType calltype;
     }
 }

--- a/contracts/interfaces/modules/IPreValidationHook.sol
+++ b/contracts/interfaces/modules/IPreValidationHook.sol
@@ -9,21 +9,12 @@ import { IModule } from "./IModule.sol";
 interface IPreValidationHookERC1271 is IModule {
     /// @notice Performs pre-validation checks for isValidSignature
     /// @dev This method is called before the validation of a signature on a validator within isValidSignature
-    /// @param account The account to validate the signature for
     /// @param sender The original sender of the request
     /// @param hash The hash of signed data
     /// @param data The signature data to validate
     /// @return hookHash The hash after applying the pre-validation hook
     /// @return hookSignature The signature after applying the pre-validation hook
-    function preValidationHookERC1271(
-        address account,
-        address sender,
-        bytes32 hash,
-        bytes calldata data
-    )
-        external
-        view
-        returns (bytes32 hookHash, bytes memory hookSignature);
+    function preValidationHookERC1271(address sender, bytes32 hash, bytes calldata data) external view returns (bytes32 hookHash, bytes memory hookSignature);
 }
 
 /// @title Nexus - IPreValidationHookERC4337 Interface
@@ -42,5 +33,6 @@ interface IPreValidationHookERC4337 is IModule {
         bytes32 userOpHash
     )
         external
+        view
         returns (bytes32 hookHash, bytes memory hookSignature);
 }

--- a/contracts/interfaces/modules/IPreValidationHook.sol
+++ b/contracts/interfaces/modules/IPreValidationHook.sol
@@ -9,7 +9,7 @@ import { IModule } from "./IModule.sol";
 interface IPreValidationHookERC1271 is IModule {
     /// @notice Performs pre-validation checks for isValidSignature
     /// @dev This method is called before the validation of a signature on a validator within isValidSignature
-    /// @param account The account calling the hook
+    /// @param account The account to validate the signature for
     /// @param sender The original sender of the request
     /// @param hash The hash of signed data
     /// @param data The signature data to validate
@@ -31,19 +31,16 @@ interface IPreValidationHookERC1271 is IModule {
 interface IPreValidationHookERC4337 is IModule {
     /// @notice Performs pre-validation checks for user operations
     /// @dev This method is called before the validation of a user operation
-    /// @param account The account calling the hook
     /// @param userOp The user operation to be validated
     /// @param missingAccountFunds The amount of funds missing in the account
     /// @param userOpHash The hash of the user operation data
     /// @return hookHash The hash after applying the pre-validation hook
     /// @return hookSignature The signature after applying the pre-validation hook
     function preValidationHookERC4337(
-        address account,
         PackedUserOperation calldata userOp,
         uint256 missingAccountFunds,
         bytes32 userOpHash
     )
         external
-        view
         returns (bytes32 hookHash, bytes memory hookSignature);
 }

--- a/contracts/interfaces/modules/IPreValidationHook.sol
+++ b/contracts/interfaces/modules/IPreValidationHook.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import { PackedUserOperation } from "account-abstraction/interfaces/PackedUserOperation.sol";
+import { IModule } from "./IModule.sol";
+
+/// @title Nexus - IPreValidationHookERC1271 Interface
+/// @notice Defines the interface for ERC-1271 pre-validation hooks
+interface IPreValidationHookERC1271 is IModule {
+    /// @notice Performs pre-validation checks for isValidSignature
+    /// @dev This method is called before the validation of a signature on a validator within isValidSignature
+    /// @param account The account calling the hook
+    /// @param sender The original sender of the request
+    /// @param hash The hash of signed data
+    /// @param data The signature data to validate
+    /// @return hookHash The hash after applying the pre-validation hook
+    /// @return hookSignature The signature after applying the pre-validation hook
+    function preValidationHookERC1271(
+        address account,
+        address sender,
+        bytes32 hash,
+        bytes calldata data
+    )
+        external
+        view
+        returns (bytes32 hookHash, bytes memory hookSignature);
+}
+
+/// @title Nexus - IPreValidationHookERC4337 Interface
+/// @notice Defines the interface for ERC-4337 pre-validation hooks
+interface IPreValidationHookERC4337 is IModule {
+    /// @notice Performs pre-validation checks for user operations
+    /// @dev This method is called before the validation of a user operation
+    /// @param account The account calling the hook
+    /// @param userOp The user operation to be validated
+    /// @param missingAccountFunds The amount of funds missing in the account
+    /// @param userOpHash The hash of the user operation data
+    /// @return hookHash The hash after applying the pre-validation hook
+    /// @return hookSignature The signature after applying the pre-validation hook
+    function preValidationHookERC4337(
+        address account,
+        PackedUserOperation calldata userOp,
+        uint256 missingAccountFunds,
+        bytes32 userOpHash
+    )
+        external
+        view
+        returns (bytes32 hookHash, bytes memory hookSignature);
+}

--- a/contracts/mocks/Mock7739PreValidationHook.sol
+++ b/contracts/mocks/Mock7739PreValidationHook.sol
@@ -30,16 +30,8 @@ contract Mock7739PreValidationHook is IPreValidationHookERC1271 {
         return forwarder == prevalidationHookMultiplexer;
     }
 
-    function preValidationHookERC1271(
-        address account,
-        address,
-        bytes32 hash,
-        bytes calldata data
-    )
-        external
-        view
-        returns (bytes32 hookHash, bytes memory hookSignature)
-    {
+    function preValidationHookERC1271(address, bytes32 hash, bytes calldata data) external view returns (bytes32 hookHash, bytes memory hookSignature) {
+        address account = _msgSender();
         // Check flag in first byte
         if (data[0] == 0x00) {
             return wrapFor7739Validation(account, hash, _erc1271UnwrapSignature(data[1:]));

--- a/contracts/mocks/Mock7739PreValidationHook.sol
+++ b/contracts/mocks/Mock7739PreValidationHook.sol
@@ -10,6 +10,26 @@ contract Mock7739PreValidationHook is IPreValidationHookERC1271 {
     bytes32 internal constant _PERSONAL_SIGN_TYPEHASH = 0x983e65e5148e570cd828ead231ee759a8d7958721a768f93bc4483ba005c32de;
     bytes32 internal constant _DOMAIN_TYPEHASH = 0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f;
 
+    address public immutable prevalidationHookMultiplexer;
+
+    constructor(address _prevalidationHookMultiplexer) {
+        prevalidationHookMultiplexer = _prevalidationHookMultiplexer;
+    }
+
+    function _msgSender() internal view returns (address sender) {
+        if (isTrustedForwarder(msg.sender) && msg.data.length >= 20) {
+            assembly {
+                sender := shr(96, calldataload(sub(calldatasize(), 20)))
+            }
+        } else {
+            return msg.sender;
+        }
+    }
+
+    function isTrustedForwarder(address forwarder) public view returns (bool) {
+        return forwarder == prevalidationHookMultiplexer;
+    }
+
     function preValidationHookERC1271(
         address account,
         address,

--- a/contracts/mocks/Mock7739PreValidationHook.sol
+++ b/contracts/mocks/Mock7739PreValidationHook.sol
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import { IPreValidationHookERC1271 } from "../interfaces/modules/IPreValidationHook.sol";
+import { MODULE_TYPE_PREVALIDATION_HOOK_ERC1271, MODULE_TYPE_PREVALIDATION_HOOK_ERC4337 } from "../types/Constants.sol";
+import { EIP712 } from "solady/utils/EIP712.sol";
+import { PackedUserOperation } from "account-abstraction/interfaces/PackedUserOperation.sol";
+
+contract Mock7739PreValidationHook is IPreValidationHookERC1271 {
+    bytes32 internal constant _PERSONAL_SIGN_TYPEHASH = 0x983e65e5148e570cd828ead231ee759a8d7958721a768f93bc4483ba005c32de;
+    bytes32 internal constant _DOMAIN_TYPEHASH = 0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f;
+
+    function preValidationHookERC1271(
+        address account,
+        address,
+        bytes32 hash,
+        bytes calldata data
+    )
+        external
+        view
+        returns (bytes32 hookHash, bytes memory hookSignature)
+    {
+        // Check flag in first byte
+        if (data[0] == 0x00) {
+            return wrapFor7739Validation(account, hash, _erc1271UnwrapSignature(data[1:]));
+        }
+        return (hash, data[1:]);
+    }
+
+    function wrapFor7739Validation(address account, bytes32 hash, bytes calldata signature) internal view virtual returns (bytes32, bytes calldata) {
+        bytes32 t = _typedDataSignFieldsForAccount(account);
+        /// @solidity memory-safe-assembly
+        assembly {
+            let m := mload(0x40) // Cache the free memory pointer.
+            // `c` is `contentsType.length`, which is stored in the last 2 bytes of the signature.
+            let c := shr(240, calldataload(add(signature.offset, sub(signature.length, 2))))
+            for { } 1 { } {
+                let l := add(0x42, c) // Total length of appended data (32 + 32 + c + 2).
+                let o := add(signature.offset, sub(signature.length, l)) // Offset of appended data.
+                mstore(0x00, 0x1901) // Store the "\x19\x01" prefix.
+                calldatacopy(0x20, o, 0x40) // Copy the `APP_DOMAIN_SEPARATOR` and `contents` struct hash.
+                // Use the `PersonalSign` workflow if the reconstructed hash doesn't match,
+                // or if the appended data is invalid, i.e.
+                // `appendedData.length > signature.length || contentsType.length == 0`.
+                if or(xor(keccak256(0x1e, 0x42), hash), or(lt(signature.length, l), iszero(c))) {
+                    t := 0 // Set `t` to 0, denoting that we need to `hash = _hashTypedData(hash)`.
+                    mstore(t, _PERSONAL_SIGN_TYPEHASH)
+                    mstore(0x20, hash) // Store the `prefixed`.
+                    hash := keccak256(t, 0x40) // Compute the `PersonalSign` struct hash.
+                    break
+                }
+                // Else, use the `TypedDataSign` workflow.
+                // `TypedDataSign({ContentsName} contents,bytes1 fields,...){ContentsType}`.
+                mstore(m, "TypedDataSign(") // Store the start of `TypedDataSign`'s type encoding.
+                let p := add(m, 0x0e) // Advance 14 bytes to skip "TypedDataSign(".
+                calldatacopy(p, add(o, 0x40), c) // Copy `contentsType` to extract `contentsName`.
+                // `d & 1 == 1` means that `contentsName` is invalid.
+                let d := shr(byte(0, mload(p)), 0x7fffffe000000000000010000000000) // Starts with `[a-z(]`.
+                // Store the end sentinel '(', and advance `p` until we encounter a '(' byte.
+                for { mstore(add(p, c), 40) } iszero(eq(byte(0, mload(p)), 40)) { p := add(p, 1) } { d := or(shr(byte(0, mload(p)), 0x120100000001), d) } // Has
+                // a byte in ", )\x00".
+
+                mstore(p, " contents,bytes1 fields,string n") // Store the rest of the encoding.
+                mstore(add(p, 0x20), "ame,string version,uint256 chain")
+                mstore(add(p, 0x40), "Id,address verifyingContract,byt")
+                mstore(add(p, 0x60), "es32 salt,uint256[] extensions)")
+                p := add(p, 0x7f)
+                calldatacopy(p, add(o, 0x40), c) // Copy `contentsType`.
+                // Fill in the missing fields of the `TypedDataSign`.
+                calldatacopy(t, o, 0x40) // Copy the `contents` struct hash to `add(t, 0x20)`.
+                mstore(t, keccak256(m, sub(add(p, c), m))) // Store `typedDataSignTypehash`.
+                // The "\x19\x01" prefix is already at 0x00.
+                // `APP_DOMAIN_SEPARATOR` is already at 0x20.
+                mstore(0x40, keccak256(t, 0x120)) // `hashStruct(typedDataSign)`.
+                // Compute the final hash, corrupted if `contentsName` is invalid.
+                hash := keccak256(0x1e, add(0x42, and(1, d)))
+                signature.length := sub(signature.length, l) // Truncate the signature.
+                break
+            }
+            mstore(0x40, m) // Restore the free memory pointer.
+        }
+        if (t == bytes32(0)) hash = _hashTypedDataForAccount(account, hash); // `PersonalSign` workflow.
+        return (hash, signature);
+    }
+
+    /// @dev Unwraps and returns the signature.
+    function _erc1271UnwrapSignature(bytes calldata signature) internal view virtual returns (bytes calldata result) {
+        result = signature;
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Unwraps the ERC6492 wrapper if it exists.
+            // See: https://eips.ethereum.org/EIPS/eip-6492
+            if eq(
+                calldataload(add(result.offset, sub(result.length, 0x20))),
+                mul(0x6492, div(not(mload(0x60)), 0xffff)) // `0x6492...6492`.
+            ) {
+                let o := add(result.offset, calldataload(add(result.offset, 0x40)))
+                result.length := calldataload(o)
+                result.offset := add(o, 0x20)
+            }
+        }
+    }
+
+    /// @dev For use in `_erc1271IsValidSignatureViaNestedEIP712`,
+    function _typedDataSignFieldsForAccount(address account) private view returns (bytes32 m) {
+        (bytes1 fields, string memory name, string memory version, uint256 chainId, address verifyingContract, bytes32 salt, uint256[] memory extensions) =
+            EIP712(account).eip712Domain();
+        /// @solidity memory-safe-assembly
+        assembly {
+            m := mload(0x40) // Grab the free memory pointer.
+            mstore(0x40, add(m, 0x120)) // Allocate the memory.
+            // Skip 2 words for the `typedDataSignTypehash` and `contents` struct hash.
+            mstore(add(m, 0x40), shl(248, byte(0, fields)))
+            mstore(add(m, 0x60), keccak256(add(name, 0x20), mload(name)))
+            mstore(add(m, 0x80), keccak256(add(version, 0x20), mload(version)))
+            mstore(add(m, 0xa0), chainId)
+            mstore(add(m, 0xc0), shr(96, shl(96, verifyingContract)))
+            mstore(add(m, 0xe0), salt)
+            mstore(add(m, 0x100), keccak256(add(extensions, 0x20), shl(5, mload(extensions))))
+        }
+    }
+
+    /// @notice Hashes typed data according to eip-712
+    ///         Uses account's domain separator
+    /// @param account the smart account, who's domain separator will be used
+    /// @param structHash the typed data struct hash
+    function _hashTypedDataForAccount(address account, bytes32 structHash) private view returns (bytes32 digest) {
+        (
+            ,
+            /*bytes1 fields*/
+            string memory name,
+            string memory version,
+            uint256 chainId,
+            address verifyingContract, /*bytes32 salt*/ /*uint256[] memory extensions*/
+            ,
+        ) = EIP712(account).eip712Domain();
+
+        /// @solidity memory-safe-assembly
+        assembly {
+            //Rebuild domain separator out of 712 domain
+            let m := mload(0x40) // Load the free memory pointer.
+            mstore(m, _DOMAIN_TYPEHASH)
+            mstore(add(m, 0x20), keccak256(add(name, 0x20), mload(name))) // Name hash.
+            mstore(add(m, 0x40), keccak256(add(version, 0x20), mload(version))) // Version hash.
+            mstore(add(m, 0x60), chainId)
+            mstore(add(m, 0x80), verifyingContract)
+            digest := keccak256(m, 0xa0) //domain separator
+
+            // Hash typed data
+            mstore(0x00, 0x1901000000000000) // Store "\x19\x01".
+            mstore(0x1a, digest) // Store the domain separator.
+            mstore(0x3a, structHash) // Store the struct hash.
+            digest := keccak256(0x18, 0x42)
+            // Restore the part of the free memory slot that was overwritten.
+            mstore(0x3a, 0)
+        }
+    }
+
+    function onInstall(bytes calldata data) external override { }
+
+    function onUninstall(bytes calldata data) external override { }
+
+    function isModuleType(uint256 moduleTypeId) external pure returns (bool) {
+        return moduleTypeId == MODULE_TYPE_PREVALIDATION_HOOK_ERC1271 || moduleTypeId == MODULE_TYPE_PREVALIDATION_HOOK_ERC4337;
+    }
+
+    function isInitialized(address) external pure returns (bool) {
+        return true;
+    }
+}

--- a/contracts/mocks/MockAccountLocker.sol
+++ b/contracts/mocks/MockAccountLocker.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import { IHook } from "../interfaces/modules/IHook.sol";
+import { MODULE_TYPE_HOOK } from "../types/Constants.sol";
+
+contract MockAccountLocker is IHook {
+    mapping(address => mapping(address => uint256)) lockedAmount;
+
+    function getLockedAmount(address account, address token) external view returns (uint256) {
+        return lockedAmount[account][token];
+    }
+
+    function setLockedAmount(address account, address token, uint256 amount) external {
+        lockedAmount[account][token] = amount;
+    }
+
+    function onInstall(bytes calldata data) external override { }
+
+    function onUninstall(bytes calldata data) external override { }
+
+    function isModuleType(uint256 moduleTypeId) external pure override returns (bool) {
+        return moduleTypeId == MODULE_TYPE_HOOK;
+    }
+
+    function isInitialized(address smartAccount) external view override returns (bool) { }
+
+    function preCheck(address msgSender, uint256 msgValue, bytes calldata msgData) external override returns (bytes memory hookData) { }
+
+    function postCheck(bytes calldata hookData) external override { }
+}

--- a/contracts/mocks/MockAccountLocker.sol
+++ b/contracts/mocks/MockAccountLocker.sol
@@ -8,11 +8,11 @@ contract MockAccountLocker is IHook {
     mapping(address => mapping(address => uint256)) lockedAmount;
 
     function getLockedAmount(address account, address token) external view returns (uint256) {
-        return lockedAmount[account][token];
+        return lockedAmount[token][account];
     }
 
     function setLockedAmount(address account, address token, uint256 amount) external {
-        lockedAmount[account][token] = amount;
+        lockedAmount[token][account] = amount;
     }
 
     function onInstall(bytes calldata data) external override { }

--- a/contracts/mocks/MockPreValidationHook.sol
+++ b/contracts/mocks/MockPreValidationHook.sol
@@ -39,7 +39,6 @@ contract MockPreValidationHook is IPreValidationHookERC1271, IPreValidationHookE
     }
 
     function preValidationHookERC4337(
-        address,
         PackedUserOperation calldata userOp,
         uint256,
         bytes32 userOpHash

--- a/contracts/mocks/MockPreValidationHook.sol
+++ b/contracts/mocks/MockPreValidationHook.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import { IPreValidationHookERC1271, IPreValidationHookERC4337, PackedUserOperation } from "../interfaces/modules/IPreValidationHook.sol";
+import { EncodedModuleTypes } from "../lib/ModuleTypeLib.sol";
+import "../types/Constants.sol";
+
+contract MockPreValidationHook is IPreValidationHookERC1271, IPreValidationHookERC4337 {
+    event PreCheckCalled();
+    event HookOnInstallCalled(bytes32 dataFirstWord);
+
+    function onInstall(bytes calldata data) external override {
+        if (data.length >= 0x20) {
+            emit HookOnInstallCalled(bytes32(data[0:32]));
+        }
+    }
+
+    function onUninstall(bytes calldata) external override { }
+
+    function isModuleType(uint256 moduleTypeId) external pure returns (bool) {
+        return moduleTypeId == MODULE_TYPE_PREVALIDATION_HOOK_ERC4337 || moduleTypeId == MODULE_TYPE_PREVALIDATION_HOOK_ERC1271;
+    }
+
+    function isInitialized(address) external pure returns (bool) {
+        return true;
+    }
+
+    function preValidationHookERC1271(
+        address,
+        address,
+        bytes32 hash,
+        bytes calldata data
+    )
+        external
+        pure
+        returns (bytes32 hookHash, bytes memory hookSignature)
+    {
+        return (hash, data);
+    }
+
+    function preValidationHookERC4337(
+        address,
+        PackedUserOperation calldata userOp,
+        uint256,
+        bytes32 userOpHash
+    )
+        external
+        pure
+        returns (bytes32 hookHash, bytes memory hookSignature)
+    {
+        return (userOpHash, userOp.signature);
+    }
+}

--- a/contracts/mocks/MockPreValidationHook.sol
+++ b/contracts/mocks/MockPreValidationHook.sol
@@ -25,16 +25,7 @@ contract MockPreValidationHook is IPreValidationHookERC1271, IPreValidationHookE
         return true;
     }
 
-    function preValidationHookERC1271(
-        address,
-        address,
-        bytes32 hash,
-        bytes calldata data
-    )
-        external
-        pure
-        returns (bytes32 hookHash, bytes memory hookSignature)
-    {
+    function preValidationHookERC1271(address, bytes32 hash, bytes calldata data) external pure returns (bytes32 hookHash, bytes memory hookSignature) {
         return (hash, data);
     }
 

--- a/contracts/mocks/MockPreValidationHookMultiplexer.sol
+++ b/contracts/mocks/MockPreValidationHookMultiplexer.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import { IPreValidationHookERC1271, IPreValidationHookERC4337, PackedUserOperation, IModule } from "../interfaces/modules/IPreValidationHook.sol";
+import { MODULE_TYPE_PREVALIDATION_HOOK_ERC1271, MODULE_TYPE_PREVALIDATION_HOOK_ERC4337 } from "../types/Constants.sol";
+
+contract MockPreValidationHookMultiplexer is IPreValidationHookERC1271, IPreValidationHookERC4337 {
+    struct HookConfig {
+        address[] hooks;
+        bool initialized;
+    }
+
+    // Separate configurations for each hook type
+    mapping(address account => mapping(uint256 hookType => HookConfig)) internal accountConfig;
+
+    error AlreadyInitialized(uint256 hookType);
+    error NotInitialized(uint256 hookType);
+    error InvalidHookType(uint256 hookType);
+    error OnInstallFailed(address hook);
+    error OnUninstallFailed(address hook);
+
+    function onInstall(bytes calldata data) external {
+        (uint256 moduleType, address[] memory hooks, bytes[] memory hookData) = abi.decode(data, (uint256, address[], bytes[]));
+
+        if (!isValidModuleType(moduleType)) {
+            revert InvalidHookType(moduleType);
+        }
+
+        if (accountConfig[msg.sender][moduleType].initialized) {
+            revert AlreadyInitialized(moduleType);
+        }
+
+        accountConfig[msg.sender][moduleType].hooks = hooks;
+        accountConfig[msg.sender][moduleType].initialized = true;
+
+        for (uint256 i = 0; i < hooks.length; i++) {
+            bytes memory subHookOnInstallCalldata = abi.encodeCall(IModule.onInstall, hookData[i]);
+            (bool success,) = hooks[i].call(abi.encodePacked(subHookOnInstallCalldata, msg.sender));
+            require(success, OnInstallFailed(hooks[i]));
+        }
+    }
+
+    function onUninstall(bytes calldata data) external {
+        (uint256 moduleType, bytes[] memory hookData) = abi.decode(data, (uint256, bytes[]));
+
+        if (!isValidModuleType(moduleType)) {
+            revert InvalidHookType(moduleType);
+        }
+
+        address[] memory hooks = accountConfig[msg.sender][moduleType].hooks;
+
+        delete accountConfig[msg.sender][moduleType];
+
+        for (uint256 i = 0; i < hooks.length; i++) {
+            bytes memory subHookOnUninstallCalldata = abi.encodeCall(IModule.onUninstall, hookData[i]);
+            (bool success,) = hooks[i].call(abi.encodePacked(subHookOnUninstallCalldata, msg.sender));
+            require(success, OnUninstallFailed(hooks[i]));
+        }
+    }
+
+    function preValidationHookERC4337(
+        address account,
+        PackedUserOperation calldata userOp,
+        uint256 missingAccountFunds,
+        bytes32 userOpHash
+    )
+        external
+        view
+        returns (bytes32 hookHash, bytes memory hookSignature)
+    {
+        HookConfig storage config = accountConfig[msg.sender][MODULE_TYPE_PREVALIDATION_HOOK_ERC4337];
+
+        if (!config.initialized) {
+            revert NotInitialized(MODULE_TYPE_PREVALIDATION_HOOK_ERC4337);
+        }
+
+        hookHash = userOpHash;
+        hookSignature = userOp.signature;
+        PackedUserOperation memory op = userOp;
+
+        for (uint256 i = 0; i < config.hooks.length; i++) {
+            (hookHash, hookSignature) = IPreValidationHookERC4337(config.hooks[i]).preValidationHookERC4337(account, op, missingAccountFunds, hookHash);
+            op.signature = hookSignature;
+        }
+
+        return (hookHash, hookSignature);
+    }
+
+    function preValidationHookERC1271(
+        address account,
+        address sender,
+        bytes32 hash,
+        bytes calldata signature
+    )
+        external
+        view
+        returns (bytes32 hookHash, bytes memory hookSignature)
+    {
+        HookConfig storage config = accountConfig[msg.sender][MODULE_TYPE_PREVALIDATION_HOOK_ERC1271];
+
+        if (!config.initialized) {
+            revert NotInitialized(MODULE_TYPE_PREVALIDATION_HOOK_ERC1271);
+        }
+
+        hookHash = hash;
+        hookSignature = signature;
+
+        for (uint256 i = 0; i < config.hooks.length; i++) {
+            (hookHash, hookSignature) = IPreValidationHookERC1271(config.hooks[i]).preValidationHookERC1271(account, sender, hookHash, hookSignature);
+        }
+
+        return (hookHash, hookSignature);
+    }
+
+    function isModuleType(uint256 moduleTypeId) external pure returns (bool) {
+        return isValidModuleType(moduleTypeId);
+    }
+
+    function isInitialized(address smartAccount) external view returns (bool) {
+        // Account is initialized if either hook type is initialized
+        return accountConfig[smartAccount][MODULE_TYPE_PREVALIDATION_HOOK_ERC4337].initialized
+            || accountConfig[smartAccount][MODULE_TYPE_PREVALIDATION_HOOK_ERC1271].initialized;
+    }
+
+    function isHookTypeInitialized(address smartAccount, uint256 hookType) external view returns (bool) {
+        return accountConfig[smartAccount][hookType].initialized;
+    }
+
+    function isValidModuleType(uint256 moduleTypeId) internal pure returns (bool) {
+        return moduleTypeId == MODULE_TYPE_PREVALIDATION_HOOK_ERC4337 || moduleTypeId == MODULE_TYPE_PREVALIDATION_HOOK_ERC1271;
+    }
+}

--- a/contracts/mocks/MockResourceLockPreValidationHook.sol
+++ b/contracts/mocks/MockResourceLockPreValidationHook.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import { IPreValidationHookERC1271, IPreValidationHookERC4337, PackedUserOperation } from "../interfaces/modules/IPreValidationHook.sol";
+import { MODULE_TYPE_PREVALIDATION_HOOK_ERC4337, MODULE_TYPE_HOOK, MODULE_TYPE_PREVALIDATION_HOOK_ERC1271 } from "../types/Constants.sol";
+import { EIP712 } from "solady/utils/EIP712.sol";
+
+interface IAccountLocker {
+    function getLockedAmount(address account, address token) external view returns (uint256);
+}
+
+interface IAccount {
+    function isModuleInstalled(uint256 moduleTypeId, address module, bytes calldata additionalContext) external view returns (bool installed);
+}
+
+contract MockResourceLockPreValidationHook is IPreValidationHookERC4337, IPreValidationHookERC1271 {
+    address constant NATIVE_TOKEN = address(0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE);
+
+    /// @dev `keccak256("PersonalSign(bytes prefixed)")`.
+    bytes32 internal constant _PERSONAL_SIGN_TYPEHASH = 0x983e65e5148e570cd828ead231ee759a8d7958721a768f93bc4483ba005c32de;
+    bytes32 internal constant _DOMAIN_TYPEHASH = 0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f;
+
+    IAccountLocker public immutable resourceLocker;
+    address public immutable prevalidationHookMultiplexer;
+
+    error InsufficientUnlockedETH(uint256 required);
+    error ResourceLockerNotInstalled();
+    error ResourceLockerInstalled();
+    error SenderIsResourceLocked();
+
+    constructor(address _resourceLocker, address _prevalidationHookMultiplexer) {
+        resourceLocker = IAccountLocker(_resourceLocker);
+        prevalidationHookMultiplexer = _prevalidationHookMultiplexer;
+    }
+
+    function isTrustedForwarder(address forwarder) public view returns (bool) {
+        return forwarder == prevalidationHookMultiplexer;
+    }
+
+    function _msgSender() internal view returns (address sender) {
+        if (isTrustedForwarder(msg.sender) && msg.data.length >= 20) {
+            assembly {
+                sender := shr(96, calldataload(sub(calldatasize(), 20)))
+            }
+        } else {
+            return msg.sender;
+        }
+    }
+
+    function onInstall(bytes calldata) external view override {
+        address sender = _msgSender();
+        require(IAccount(sender).isModuleInstalled(MODULE_TYPE_HOOK, address(resourceLocker), ""), ResourceLockerNotInstalled());
+    }
+
+    function onUninstall(bytes calldata) external view override {
+        address sender = _msgSender();
+        require(!IAccount(sender).isModuleInstalled(MODULE_TYPE_HOOK, address(resourceLocker), ""), ResourceLockerInstalled());
+    }
+
+    function isModuleType(uint256 moduleTypeId) external pure returns (bool) {
+        return moduleTypeId == MODULE_TYPE_PREVALIDATION_HOOK_ERC4337 || moduleTypeId == MODULE_TYPE_PREVALIDATION_HOOK_ERC1271;
+    }
+
+    function isInitialized(address) external pure returns (bool) {
+        return true;
+    }
+
+    function preValidationHookERC4337(
+        address account,
+        PackedUserOperation calldata userOp,
+        uint256 missingAccountFunds,
+        bytes32 userOpHash
+    )
+        external
+        view
+        returns (bytes32 hookHash, bytes memory hookSignature)
+    {
+        require(enoughETHAvailable(account, missingAccountFunds), InsufficientUnlockedETH(missingAccountFunds));
+        return (userOpHash, userOp.signature);
+    }
+
+    function enoughETHAvailable(address account, uint256 requiredAmount) internal view returns (bool) {
+        if (requiredAmount == 0) {
+            return true;
+        }
+
+        uint256 lockedAmount = resourceLocker.getLockedAmount(account, NATIVE_TOKEN);
+        uint256 unlockedAmount = address(account).balance - lockedAmount;
+
+        return unlockedAmount >= requiredAmount;
+    }
+
+    function preValidationHookERC1271(
+        address account,
+        address sender,
+        bytes32 hash,
+        bytes calldata data
+    )
+        external
+        view
+        override
+        returns (bytes32 hookHash, bytes memory hookSignature)
+    {
+        require(notResourceLocked(account, sender), SenderIsResourceLocked());
+        return (hash, data);
+    }
+
+    function notResourceLocked(address account, address sender) internal view returns (bool) {
+        uint256 lockedAmount = resourceLocker.getLockedAmount(account, sender);
+        return lockedAmount == 0;
+    }
+}

--- a/contracts/mocks/MockResourceLockPreValidationHook.sol
+++ b/contracts/mocks/MockResourceLockPreValidationHook.sol
@@ -91,7 +91,6 @@ contract MockResourceLockPreValidationHook is IPreValidationHookERC4337, IPreVal
     }
 
     function preValidationHookERC1271(
-        address account,
         address sender,
         bytes32 hash,
         bytes calldata data
@@ -101,6 +100,7 @@ contract MockResourceLockPreValidationHook is IPreValidationHookERC4337, IPreVal
         override
         returns (bytes32 hookHash, bytes memory hookSignature)
     {
+        address account = _msgSender();
         require(notResourceLocked(account, sender), SenderIsResourceLocked());
         return (hash, data);
     }

--- a/contracts/mocks/MockResourceLockPreValidationHook.sol
+++ b/contracts/mocks/MockResourceLockPreValidationHook.sol
@@ -66,7 +66,6 @@ contract MockResourceLockPreValidationHook is IPreValidationHookERC4337, IPreVal
     }
 
     function preValidationHookERC4337(
-        address account,
         PackedUserOperation calldata userOp,
         uint256 missingAccountFunds,
         bytes32 userOpHash
@@ -75,6 +74,7 @@ contract MockResourceLockPreValidationHook is IPreValidationHookERC4337, IPreVal
         view
         returns (bytes32 hookHash, bytes memory hookSignature)
     {
+        address account = _msgSender();
         require(enoughETHAvailable(account, missingAccountFunds), InsufficientUnlockedETH(missingAccountFunds));
         return (userOpHash, userOp.signature);
     }

--- a/contracts/mocks/MockSimpleValidator.sol
+++ b/contracts/mocks/MockSimpleValidator.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import { IValidator } from "../interfaces/modules/IValidator.sol";
+import { VALIDATION_SUCCESS, VALIDATION_FAILED, MODULE_TYPE_VALIDATOR } from "../types/Constants.sol";
+import { PackedUserOperation } from "account-abstraction/interfaces/PackedUserOperation.sol";
+import { ECDSA } from "solady/utils/ECDSA.sol";
+
+contract MockSimpleValidator is IValidator {
+    using ECDSA for bytes32;
+
+    mapping(address => address) public smartAccountOwners;
+
+    function validateUserOp(PackedUserOperation calldata userOp, bytes32 userOpHash) external view returns (uint256) {
+        address owner = smartAccountOwners[msg.sender];
+        return verify(owner, userOpHash, userOp.signature) ? VALIDATION_SUCCESS : VALIDATION_FAILED;
+    }
+
+    function isValidSignatureWithSender(address, bytes32 hash, bytes calldata signature) external view returns (bytes4) {
+        address owner = smartAccountOwners[msg.sender];
+        return verify(owner, hash, signature) ? bytes4(0x1626ba7e) : bytes4(0xffffffff);
+    }
+
+    function verify(address signer, bytes32 hash, bytes calldata signature) internal view returns (bool) {
+        if (signer == hash.recover(signature)) {
+            return true;
+        }
+        if (signer == hash.toEthSignedMessageHash().recover(signature)) {
+            return true;
+        }
+        return false;
+    }
+
+    function onInstall(bytes calldata data) external {
+        smartAccountOwners[msg.sender] = address(bytes20(data));
+    }
+
+    function onUninstall(bytes calldata) external {
+        delete smartAccountOwners[msg.sender];
+    }
+
+    function isModuleType(uint256 moduleTypeId) external pure returns (bool) {
+        return moduleTypeId == MODULE_TYPE_VALIDATOR;
+    }
+
+    function isInitialized(address) external pure returns (bool) {
+        return false;
+    }
+}

--- a/contracts/types/Constants.sol
+++ b/contracts/types/Constants.sol
@@ -39,8 +39,15 @@ uint256 constant MODULE_TYPE_FALLBACK = 3;
 // Module type identifier for hooks
 uint256 constant MODULE_TYPE_HOOK = 4;
 
+// Module type identifiers for pre-validation hooks
+uint256 constant MODULE_TYPE_PREVALIDATION_HOOK_ERC1271 = 8;
+uint256 constant MODULE_TYPE_PREVALIDATION_HOOK_ERC4337 = 9;
+
 string constant MODULE_ENABLE_MODE_NOTATION = "ModuleEnableMode(address module,uint256 moduleType,bytes32 userOpHash,bytes32 initDataHash)";
 bytes32 constant MODULE_ENABLE_MODE_TYPE_HASH = keccak256(bytes(MODULE_ENABLE_MODE_NOTATION));
+
+string constant EMERGENCY_UNINSTALL_NOTATION = "EmergencyUninstall(address hook,uint256 hookType,bytes deInitData,uint256 nonce)";
+bytes32 constant EMERGENCY_UNINSTALL_TYPE_HASH = keccak256(bytes(EMERGENCY_UNINSTALL_NOTATION));
 
 // Validation modes
 bytes1 constant MODE_VALIDATION = 0x00;

--- a/contracts/types/DataTypes.sol
+++ b/contracts/types/DataTypes.sol
@@ -22,3 +22,16 @@ struct Execution {
     /// @notice The calldata for the transaction
     bytes callData;
 }
+
+/// @title Emergency Uninstall
+/// @notice Struct to encapsulate emergency uninstall data for a hook
+struct EmergencyUninstall {
+    /// @notice The address of the hook to be uninstalled
+    address hook;
+    /// @notice The hook type identifier
+    uint256 hookType;
+    /// @notice Data used to uninstall the hook
+    bytes deInitData;
+    /// @notice Nonce used to prevent replay attacks
+    uint256 nonce;
+}

--- a/test/foundry/integration/TestNexusPreValidation_Integration_Multiplexer.t.sol
+++ b/test/foundry/integration/TestNexusPreValidation_Integration_Multiplexer.t.sol
@@ -31,8 +31,8 @@ contract TestNexusPreValidation_Integration_HookMultiplexer is TestModuleManagem
 
         // Deploy supporting contracts
         accountLocker = new MockAccountLocker();
-        erc7739Hook = new Mock7739PreValidationHook();
         hookMultiplexer = new MockPreValidationHookMultiplexer();
+        erc7739Hook = new Mock7739PreValidationHook(address(hookMultiplexer));
         resourceLockHook = new MockResourceLockPreValidationHook(address(accountLocker), address(hookMultiplexer));
         // Deploy the simple validator
         SIMPLE_VALIDATOR = new MockSimpleValidator();
@@ -132,7 +132,7 @@ contract TestNexusPreValidation_Integration_HookMultiplexer is TestModuleManagem
         test_installMultiplePreValidationHooks();
 
         // Lock resources
-        vm.prank(address(accountLocker));
+
         MockAccountLocker(accountLocker).setLockedAmount(address(BOB_ACCOUNT), address(this), 1);
 
         // Prepare test data

--- a/test/foundry/integration/TestNexusPreValidation_Integration_Multiplexer.t.sol
+++ b/test/foundry/integration/TestNexusPreValidation_Integration_Multiplexer.t.sol
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import "../shared/TestModuleManagement_Base.t.sol";
+import { MockPreValidationHookMultiplexer } from "../../../contracts/mocks/MockPreValidationHookMultiplexer.sol";
+import { MockResourceLockPreValidationHook } from "../../../contracts/mocks/MockResourceLockPreValidationHook.sol";
+import { Mock7739PreValidationHook } from "../../../contracts/mocks/Mock7739PreValidationHook.sol";
+import { MockAccountLocker } from "../../../contracts/mocks/MockAccountLocker.sol";
+import { MockSimpleValidator } from "../../../contracts/mocks/MockSimpleValidator.sol";
+
+/// @title TestNexusPreValidation_Integration_HookMultiplexer
+/// @notice This contract tests the integration of the PreValidation hook multiplexer with the PreValidation resource lock hooks
+contract TestNexusPreValidation_Integration_HookMultiplexer is TestModuleManagement_Base {
+    MockPreValidationHookMultiplexer private hookMultiplexer;
+    MockResourceLockPreValidationHook private resourceLockHook;
+    Mock7739PreValidationHook private erc7739Hook;
+    MockAccountLocker private accountLocker;
+    MockSimpleValidator private SIMPLE_VALIDATOR;
+
+    struct TestTemps {
+        bytes32 contents;
+        uint8 v;
+        bytes32 r;
+        bytes32 s;
+    }
+
+    bytes32 internal constant APP_DOMAIN_SEPARATOR = 0xa1a044077d7677adbbfa892ded5390979b33993e0e2a457e3f974bbcda53821b;
+
+    function setUp() public {
+        setUpModuleManagement_Base();
+
+        // Deploy supporting contracts
+        accountLocker = new MockAccountLocker();
+        erc7739Hook = new Mock7739PreValidationHook();
+        hookMultiplexer = new MockPreValidationHookMultiplexer();
+        resourceLockHook = new MockResourceLockPreValidationHook(address(accountLocker), address(hookMultiplexer));
+        // Deploy the simple validator
+        SIMPLE_VALIDATOR = new MockSimpleValidator();
+        // Format install data with owner
+        bytes memory validatorSetupData = abi.encodePacked(BOB_ADDRESS); // Set BOB as owner
+        // Prepare the call data for installing the validator module
+        bytes memory callData =
+            abi.encodeWithSelector(IModuleManager.installModule.selector, MODULE_TYPE_VALIDATOR, address(SIMPLE_VALIDATOR), validatorSetupData);
+        // Install validator module using execution
+        installModule(callData, MODULE_TYPE_VALIDATOR, address(SIMPLE_VALIDATOR), EXECTYPE_DEFAULT);
+        // Prepare calldata for installing the account locker
+        bytes memory accountLockerInstallCallData = abi.encodeWithSelector(IModuleManager.installModule.selector, MODULE_TYPE_HOOK, address(accountLocker), "");
+        // Install account locker
+        installModule(accountLockerInstallCallData, MODULE_TYPE_HOOK, address(accountLocker), EXECTYPE_DEFAULT);
+    }
+
+    function test_installMultiplePreValidationHooks() public {
+        // Install hooks for 4337
+        address[] memory hooks4337 = new address[](1);
+        hooks4337[0] = address(resourceLockHook);
+        bytes[] memory hookData4337 = new bytes[](1);
+        hookData4337[0] = "foo";
+
+        // Install hooks for 1271
+        address[] memory hooks1271 = new address[](2);
+        hooks1271[0] = address(resourceLockHook);
+        hooks1271[1] = address(erc7739Hook);
+        bytes[] memory hookData1271 = new bytes[](2);
+        hookData1271[0] = "foo";
+        hookData1271[1] = "bar";
+
+        // Install 4337 hooks
+        bytes memory installData4337 = abi.encode(MODULE_TYPE_PREVALIDATION_HOOK_ERC4337, hooks4337, hookData4337);
+        bytes memory installCallData4337 =
+            abi.encodeWithSelector(IModuleManager.installModule.selector, MODULE_TYPE_PREVALIDATION_HOOK_ERC4337, address(hookMultiplexer), installData4337);
+        installModule(installCallData4337, MODULE_TYPE_PREVALIDATION_HOOK_ERC4337, address(hookMultiplexer), EXECTYPE_DEFAULT);
+
+        // Install 1271 hooks
+        bytes memory installData1271 = abi.encode(MODULE_TYPE_PREVALIDATION_HOOK_ERC1271, hooks1271, hookData1271);
+        bytes memory installCallData1271 =
+            abi.encodeWithSelector(IModuleManager.installModule.selector, MODULE_TYPE_PREVALIDATION_HOOK_ERC1271, address(hookMultiplexer), installData1271);
+        installModule(installCallData1271, MODULE_TYPE_PREVALIDATION_HOOK_ERC1271, address(hookMultiplexer), EXECTYPE_DEFAULT);
+
+        // Verify multiplexer is installed for both types
+        assertTrue(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_PREVALIDATION_HOOK_ERC4337, address(hookMultiplexer), ""), "4337 multiplexer should be installed");
+        assertTrue(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_PREVALIDATION_HOOK_ERC1271, address(hookMultiplexer), ""), "1271 multiplexer should be installed");
+    }
+
+    function test_1271_HookChaining_MockValidator_Success() public {
+        // Install hooks and multiplexer
+        test_installMultiplePreValidationHooks();
+
+        // Prepare test data
+        TestTemps memory t;
+        t.contents = keccak256("test message");
+
+        // Create signature data for personal sign
+        bytes32 hashToSign = toERC1271HashPersonalSign(t.contents, address(BOB_ACCOUNT));
+        (t.v, t.r, t.s) = vm.sign(BOB.privateKey, hashToSign);
+
+        // Prepare signature with validator prefix and triggering both hooks
+        bytes memory signature = abi.encodePacked(t.r, t.s, t.v);
+        bytes memory validatorSignature = abi.encodePacked(
+            address(VALIDATOR_MODULE),
+            bytes1(0x01), // Skip 7739 wrap
+            signature
+        );
+
+        // Validate signature through hook chain
+        bytes4 result = BOB_ACCOUNT.isValidSignature(t.contents, validatorSignature);
+        assertEq(result, bytes4(0x1626ba7e), "Signature should be valid after hook chaining");
+    }
+
+    function test_1271_HookChaining_MockSimpleValidator_Success() public {
+        // Install hooks and multiplexer
+        test_installMultiplePreValidationHooks();
+
+        // Prepare test data
+        TestTemps memory t;
+        t.contents = keccak256("test message");
+
+        // Create signature data for personal sign
+        bytes32 hashToSign = toERC1271HashPersonalSign(t.contents, address(BOB_ACCOUNT));
+        (t.v, t.r, t.s) = vm.sign(BOB.privateKey, hashToSign);
+
+        // Prepare signature with validator prefix and triggering both hooks
+        bytes memory signature = abi.encodePacked(t.r, t.s, t.v);
+        bytes memory validatorSignature = abi.encodePacked(address(SIMPLE_VALIDATOR), bytes1(0x00), signature);
+
+        // Validate signature through hook chain
+        bytes4 result = BOB_ACCOUNT.isValidSignature(t.contents, validatorSignature);
+        assertEq(result, bytes4(0x1626ba7e), "Signature should be valid after hook chaining");
+    }
+
+    function test_1271_HookChaining_Fails_WhenResourceLocked() public {
+        // Install hooks and multiplexer
+        test_installMultiplePreValidationHooks();
+
+        // Lock resources
+        vm.prank(address(accountLocker));
+        MockAccountLocker(accountLocker).setLockedAmount(address(BOB_ACCOUNT), address(this), 1);
+
+        // Prepare test data
+        TestTemps memory t;
+        t.contents = keccak256("test message");
+
+        // Create signature data
+        bytes32 hashToSign = toERC1271HashPersonalSign(t.contents, address(BOB_ACCOUNT));
+        (t.v, t.r, t.s) = vm.sign(BOB.privateKey, hashToSign);
+
+        // Prepare signature with validator prefix
+        bytes memory signature = abi.encodePacked(t.r, t.s, t.v);
+        bytes memory validatorSignature = abi.encodePacked(
+            address(VALIDATOR_MODULE),
+            bytes1(0x00), // Trigger 7739 wrap
+            signature
+        );
+
+        // Expect revert due to resource lock
+        vm.expectRevert(abi.encodeWithSelector(MockResourceLockPreValidationHook.SenderIsResourceLocked.selector));
+        BOB_ACCOUNT.isValidSignature(t.contents, validatorSignature);
+    }
+
+    // Helper function to generate ERC-1271 hash for personal sign
+    function toERC1271HashPersonalSign(bytes32 childHash, address account) internal view returns (bytes32) {
+        AccountDomainStruct memory t;
+        (t.fields, t.name, t.version, t.chainId, t.verifyingContract, t.salt, t.extensions) = EIP712(account).eip712Domain();
+        bytes32 domainSeparator = keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                keccak256(bytes(t.name)),
+                keccak256(bytes(t.version)),
+                t.chainId,
+                t.verifyingContract
+            )
+        );
+        bytes32 parentStructHash = keccak256(abi.encode(keccak256("PersonalSign(bytes prefixed)"), childHash));
+        return keccak256(abi.encodePacked("\x19\x01", domainSeparator, parentStructHash));
+    }
+
+    struct AccountDomainStruct {
+        bytes1 fields;
+        string name;
+        string version;
+        uint256 chainId;
+        address verifyingContract;
+        bytes32 salt;
+        uint256[] extensions;
+    }
+}

--- a/test/foundry/integration/TestNexusPreValidation_Integration_ResourceLockHooks.t.sol
+++ b/test/foundry/integration/TestNexusPreValidation_Integration_ResourceLockHooks.t.sol
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import "../shared/TestModuleManagement_Base.t.sol";
+import { MockResourceLockPreValidationHook } from "../../../contracts/mocks/MockResourceLockPreValidationHook.sol";
+import { MockAccountLocker } from "../../../contracts/mocks/MockAccountLocker.sol";
+
+/// @title TestNexusPreValidation_Integration_ResourceLockHooks
+/// @notice This contract tests the integration of ResourceLock hook with the PreValidation resource lock hooks
+contract TestNexusPreValidation_Integration_ResourceLockHooks is TestModuleManagement_Base {
+    MockResourceLockPreValidationHook private resourceLockHook;
+    MockAccountLocker private accountLocker;
+
+    address internal constant NATIVE_TOKEN = address(0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE);
+    bytes32 internal constant APP_DOMAIN_SEPARATOR = 0xa1a044077d7677adbbfa892ded5390979b33993e0e2a457e3f974bbcda53821b;
+
+    struct TestTemps {
+        bytes32 contents;
+        address signer;
+        uint256 privateKey;
+        uint8 v;
+        bytes32 r;
+        bytes32 s;
+    }
+
+    function setUp() public {
+        setUpModuleManagement_Base();
+        accountLocker = new MockAccountLocker();
+        resourceLockHook = new MockResourceLockPreValidationHook(address(accountLocker), address(0));
+    }
+
+    /// @notice Tests installing the account locker and resource lock hook
+    function test_InstallResourceLockHooks() public {
+        installResourceLockHooks();
+        // Verify hooks are installed
+        assertTrue(
+            BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_PREVALIDATION_HOOK_ERC4337, address(resourceLockHook), ""), "Resource lock 4337 hook should be installed"
+        );
+        assertTrue(
+            BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_PREVALIDATION_HOOK_ERC1271, address(resourceLockHook), ""), "Resource lock 1271 hook should be installed"
+        );
+        assertTrue(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(accountLocker), ""), "Account locker should be installed");
+    }
+
+    /// @notice Fuzz test for pre-validation hook when ETH is locked
+    /// @param lockedAmount Amount of ETH to lock
+    /// @param missingAccountFunds Funds missing from the account
+    function testFuzz_4337_PreValidationHook_RevertsWhen_InsufficientUnlockedETH(uint256 lockedAmount, uint256 missingAccountFunds) public {
+        // Constrain inputs to reasonable ranges
+        vm.assume(lockedAmount > 0);
+        vm.assume(missingAccountFunds > 0);
+
+        // Install resource lock hooks
+        installResourceLockHooks();
+
+        // Prepare user operation
+        PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
+        userOps[0] = buildUserOpWithCalldata(BOB, "", address(VALIDATOR_MODULE));
+
+        // Set locked amount to block ETH transactions
+        vm.prank(address(accountLocker));
+        MockAccountLocker(accountLocker).setLockedAmount(address(BOB_ACCOUNT), NATIVE_TOKEN, lockedAmount);
+
+        // Ensure account has enough total balance
+        vm.deal(address(BOB_ACCOUNT), lockedAmount);
+        assertTrue(address(BOB_ACCOUNT).balance == lockedAmount, "Account should have correct balance");
+
+        // Calculate user op hash
+        bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
+
+        // Sign the user operation
+        userOps[0].signature = signMessage(BOB, userOpHash);
+
+        // Expect revert due to insufficient unlocked ETH
+        vm.expectRevert(abi.encodeWithSelector(MockResourceLockPreValidationHook.InsufficientUnlockedETH.selector, missingAccountFunds));
+
+        // Attempt to validate the user operation
+        startPrank(address(ENTRYPOINT));
+        BOB_ACCOUNT.validateUserOp(userOps[0], userOpHash, missingAccountFunds);
+        stopPrank();
+    }
+
+    /// @notice Fuzz test for pre-validation hook when sufficient ETH is unlocked
+    /// @param lockedAmount Amount of ETH to lock
+    /// @param totalBalance Total balance of the account
+    function testFuzz_4337_PreValidationHook_Success(uint256 lockedAmount, uint256 totalBalance) public {
+        // Constrain inputs to reasonable ranges
+        vm.assume(lockedAmount > 0);
+        vm.assume(totalBalance > lockedAmount);
+
+        // Install resource lock hooks
+        installResourceLockHooks();
+
+        // Prepare user operation
+        PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
+        userOps[0] = buildUserOpWithCalldata(BOB, "", address(VALIDATOR_MODULE));
+
+        // Set locked amount
+        vm.prank(address(accountLocker));
+        MockAccountLocker(accountLocker).setLockedAmount(address(BOB_ACCOUNT), NATIVE_TOKEN, lockedAmount);
+
+        // Ensure account has enough total balance
+        vm.deal(address(BOB_ACCOUNT), totalBalance);
+        assertTrue(address(BOB_ACCOUNT).balance == totalBalance, "Account should have correct balance");
+
+        // Calculate user op hash
+        bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
+
+        // Sign the user operation
+        userOps[0].signature = signMessage(BOB, userOpHash);
+
+        // Attempt to validate the user operation when unlocked balance is sufficient
+        vm.assume(totalBalance - lockedAmount >= 0);
+        startPrank(address(ENTRYPOINT));
+        uint256 result = BOB_ACCOUNT.validateUserOp(userOps[0], userOpHash, 0);
+        assertTrue(result == 0, "Validation should succeed");
+        stopPrank();
+    }
+
+    /// @notice Tests signature validation succeeds when resource is not locked
+    function test_1271_PreValidationHook_Success() public {
+        // Install resource lock hooks
+        installResourceLockHooks();
+
+        // Prepare signature
+        TestTemps memory t;
+        t.contents = keccak256("123");
+        bytes32 hashToSign = toERC1271HashPersonalSign(t.contents, address(BOB_ACCOUNT));
+        (t.v, t.r, t.s) = vm.sign(BOB.privateKey, hashToSign);
+
+        // Prepare signature with validator prefix
+        bytes memory signature = abi.encodePacked(t.r, t.s, t.v);
+        bytes memory validatorSignature = abi.encodePacked(address(VALIDATOR_MODULE), signature);
+
+        // Validate signature
+        bytes4 result = BOB_ACCOUNT.isValidSignature(t.contents, validatorSignature);
+        assertEq(result, bytes4(0x1626ba7e), "Signature should be valid");
+    }
+
+    /// @notice Tests signature validation fails when resource is locked
+    function test_1271_PreValidationHook_RevertsWhen_ResourceLocked() public {
+        // Install resource lock hooks
+        installResourceLockHooks();
+
+        // Prepare signature
+        TestTemps memory t;
+        t.contents = keccak256("123");
+        bytes32 hashToSign = toERC1271HashPersonalSign(t.contents, address(BOB_ACCOUNT));
+        (t.v, t.r, t.s) = vm.sign(BOB.privateKey, hashToSign);
+
+        // Prepare signature with validator prefix
+        bytes memory signature = abi.encodePacked(t.r, t.s, t.v);
+        bytes memory validatorSignature = abi.encodePacked(address(VALIDATOR_MODULE), signature);
+
+        // Set locked amount to block signature validation
+        vm.prank(address(accountLocker));
+        MockAccountLocker(accountLocker).setLockedAmount(address(BOB_ACCOUNT), address(this), 1);
+
+        // Expect revert due to resource lock
+        vm.expectRevert(abi.encodeWithSelector(MockResourceLockPreValidationHook.SenderIsResourceLocked.selector));
+        BOB_ACCOUNT.isValidSignature(t.contents, validatorSignature);
+    }
+
+    function installResourceLockHooks() internal {
+        // Install account locker first
+        bytes memory accountLockerInstallCallData = abi.encodeWithSelector(IModuleManager.installModule.selector, MODULE_TYPE_HOOK, address(accountLocker), "");
+        installModule(accountLockerInstallCallData, MODULE_TYPE_HOOK, address(accountLocker), EXECTYPE_DEFAULT);
+
+        // Install resource lock pre-validation 4337 hook
+        bytes memory resourceLockHook4337InstallCallData =
+            abi.encodeWithSelector(IModuleManager.installModule.selector, MODULE_TYPE_PREVALIDATION_HOOK_ERC4337, address(resourceLockHook), "");
+        installModule(resourceLockHook4337InstallCallData, MODULE_TYPE_PREVALIDATION_HOOK_ERC4337, address(resourceLockHook), EXECTYPE_DEFAULT);
+
+        // Install resource lock pre-validation 1271 hook
+        bytes memory resourceLockHook1271InstallCallData =
+            abi.encodeWithSelector(IModuleManager.installModule.selector, MODULE_TYPE_PREVALIDATION_HOOK_ERC1271, address(resourceLockHook), "");
+        installModule(resourceLockHook1271InstallCallData, MODULE_TYPE_PREVALIDATION_HOOK_ERC1271, address(resourceLockHook), EXECTYPE_DEFAULT);
+    }
+
+    /// @notice Generates an ERC-1271 hash for personal sign.
+    /// @param childHash The child hash.
+    /// @return The ERC-1271 hash for personal sign.
+    function toERC1271HashPersonalSign(bytes32 childHash, address account) internal view returns (bytes32) {
+        AccountDomainStruct memory t;
+        (t.fields, t.name, t.version, t.chainId, t.verifyingContract, t.salt, t.extensions) = EIP712(account).eip712Domain();
+        bytes32 domainSeparator = keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                keccak256(bytes(t.name)),
+                keccak256(bytes(t.version)),
+                t.chainId,
+                t.verifyingContract // veryfingContract should be the account address.
+            )
+        );
+        bytes32 parentStructHash = keccak256(abi.encode(keccak256("PersonalSign(bytes prefixed)"), childHash));
+        return keccak256(abi.encodePacked("\x19\x01", domainSeparator, parentStructHash));
+    }
+
+    struct AccountDomainStruct {
+        bytes1 fields;
+        string name;
+        string version;
+        uint256 chainId;
+        address verifyingContract;
+        bytes32 salt;
+        uint256[] extensions;
+    }
+}

--- a/test/foundry/integration/TestNexusPreValidation_Integration_ResourceLockHooks.t.sol
+++ b/test/foundry/integration/TestNexusPreValidation_Integration_ResourceLockHooks.t.sol
@@ -58,7 +58,7 @@ contract TestNexusPreValidation_Integration_ResourceLockHooks is TestModuleManag
         userOps[0] = buildUserOpWithCalldata(BOB, "", address(VALIDATOR_MODULE));
 
         // Set locked amount to block ETH transactions
-        vm.prank(address(accountLocker));
+
         MockAccountLocker(accountLocker).setLockedAmount(address(BOB_ACCOUNT), NATIVE_TOKEN, lockedAmount);
 
         // Ensure account has enough total balance
@@ -96,7 +96,7 @@ contract TestNexusPreValidation_Integration_ResourceLockHooks is TestModuleManag
         userOps[0] = buildUserOpWithCalldata(BOB, "", address(VALIDATOR_MODULE));
 
         // Set locked amount
-        vm.prank(address(accountLocker));
+
         MockAccountLocker(accountLocker).setLockedAmount(address(BOB_ACCOUNT), NATIVE_TOKEN, lockedAmount);
 
         // Ensure account has enough total balance
@@ -153,7 +153,7 @@ contract TestNexusPreValidation_Integration_ResourceLockHooks is TestModuleManag
         bytes memory validatorSignature = abi.encodePacked(address(VALIDATOR_MODULE), signature);
 
         // Set locked amount to block signature validation
-        vm.prank(address(accountLocker));
+
         MockAccountLocker(accountLocker).setLockedAmount(address(BOB_ACCOUNT), address(this), 1);
 
         // Expect revert due to resource lock

--- a/test/foundry/unit/concrete/hook/TestNexus_Hook_Emergency_Uninstall.sol
+++ b/test/foundry/unit/concrete/hook/TestNexus_Hook_Emergency_Uninstall.sol
@@ -3,212 +3,692 @@ pragma solidity ^0.8.27;
 
 import "../../../shared/TestModuleManagement_Base.t.sol";
 import "../../../../../contracts/mocks/MockHook.sol";
+import { MockSimpleValidator } from "../../../../../contracts/mocks/MockSimpleValidator.sol";
+import { MockPreValidationHook } from "../../../../../contracts/mocks/MockPreValidationHook.sol";
+import { EMERGENCY_UNINSTALL_TYPE_HASH } from "../../../../../contracts/types/Constants.sol";
+import { EmergencyUninstall } from "../../../../../contracts/types/DataTypes.sol";
 
 /// @title TestNexus_Hook_Uninstall
 /// @notice Tests for handling hooks emergency uninstall
 contract TestNexus_Hook_Emergency_Uninstall is TestModuleManagement_Base {
+    MockSimpleValidator SIMPLE_VALIDATOR_MODULE;
+
     /// @notice Sets up the base module management environment.
     function setUp() public {
         setUpModuleManagement_Base();
+        // Deploy  simple validator
+        SIMPLE_VALIDATOR_MODULE = new MockSimpleValidator();
+
+        // Format install data with owner
+        bytes memory validatorSetupData = abi.encodePacked(BOB_ADDRESS); // Set BOB as owner
+
+        // Prepare the call data for installing the validator module
+        bytes memory callData =
+            abi.encodeWithSelector(IModuleManager.installModule.selector, MODULE_TYPE_VALIDATOR, address(SIMPLE_VALIDATOR_MODULE), validatorSetupData);
+
+        // Install validator module using execution
+        installModule(callData, MODULE_TYPE_VALIDATOR, address(SIMPLE_VALIDATOR_MODULE), EXECTYPE_DEFAULT);
+
+        // Assert that bob is the owner
+        assertTrue(SIMPLE_VALIDATOR_MODULE.smartAccountOwners(address(BOB_ACCOUNT)) == BOB_ADDRESS, "Bob should be the owner");
     }
 
     /// @notice Tests the successful installation of the hook module, then tests initiate emergency uninstall.
     function test_EmergencyUninstallHook_Initiate_Success() public {
         // 1. Install the hook
-
-        // Ensure the hook module is not installed initially
-        assertFalse(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""), "Hook module should not be installed initially");
-
-        // Prepare call data for installing the hook module
+        assertFalse(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""));
         bytes memory callData = abi.encodeWithSelector(IModuleManager.installModule.selector, MODULE_TYPE_HOOK, address(HOOK_MODULE), "");
-
-        // Install the hook module
         installModule(callData, MODULE_TYPE_HOOK, address(HOOK_MODULE), EXECTYPE_DEFAULT);
+        assertTrue(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""));
 
-        // Assert that the hook module is now installed
-        assertTrue(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""), "Hook module should be installed");
+        // 2. Sign and request emergency uninstall
+        EmergencyUninstall memory emergencyUninstall = EmergencyUninstall(address(HOOK_MODULE), MODULE_TYPE_HOOK, "", 0);
+        // Get the hash of the emergency uninstall data
+        bytes32 hash = _hashTypedData(
+            keccak256(
+                abi.encode(
+                    EMERGENCY_UNINSTALL_TYPE_HASH,
+                    emergencyUninstall.hook,
+                    emergencyUninstall.hookType,
+                    keccak256(emergencyUninstall.deInitData),
+                    emergencyUninstall.nonce
+                )
+            ),
+            address(BOB_ACCOUNT)
+        );
 
-        uint256 prevTimeStamp = block.timestamp;
+        // Format signature with validator address prefix
+        bytes memory signature = abi.encodePacked(
+            address(SIMPLE_VALIDATOR_MODULE), // First 20 bytes is validator
+            sign(BOB, hash) // Rest is signature
+        );
 
+        bytes memory emergencyUninstallCalldata = abi.encodeWithSelector(
+            Nexus.emergencyUninstallHook.selector,
+            emergencyUninstall, // EmergencyUninstall struct
+            signature
+        );
 
-
-        // 2. Request to uninstall the hook
-        bytes memory emergencyUninstallCalldata = abi.encodeWithSelector(Nexus.emergencyUninstallHook.selector, address(HOOK_MODULE), "");
-
-        // Initialize the userOps array with one operation
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
-        userOps[0] = buildPackedUserOp(address(BOB_ACCOUNT), getNonce(address(BOB_ACCOUNT), MODE_VALIDATION, address(VALIDATOR_MODULE), bytes3(0)));
+        userOps[0] = buildPackedUserOp(address(BOB_ACCOUNT), getNonce(address(BOB_ACCOUNT), MODE_VALIDATION, address(SIMPLE_VALIDATOR_MODULE), bytes3(0)));
         userOps[0].callData = emergencyUninstallCalldata;
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
-        userOps[0].signature = signMessage(BOB, userOpHash);
+        userOps[0].signature = sign(BOB, userOpHash);
 
         vm.expectEmit(true, true, true, true);
         emit EmergencyHookUninstallRequest(address(HOOK_MODULE), block.timestamp);
 
         ENTRYPOINT.handleOps(userOps, payable(BOB.addr));
 
-        assertTrue(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""), "Hook MUST still be installed");
+        assertTrue(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""));
     }
 
     function test_EmergencyUninstallHook_Fail_AfterInitiated() public {
         // 1. Install the hook
-
-        // Ensure the hook module is not installed initially
-        assertFalse(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""), "Hook module should not be installed initially");
-
-        // Prepare call data for installing the hook module
+        assertFalse(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""));
         bytes memory callData = abi.encodeWithSelector(IModuleManager.installModule.selector, MODULE_TYPE_HOOK, address(HOOK_MODULE), "");
-
-        // Install the hook module
         installModule(callData, MODULE_TYPE_HOOK, address(HOOK_MODULE), EXECTYPE_DEFAULT);
+        assertTrue(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""));
 
-        // Assert that the hook module is now installed
-        assertTrue(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""), "Hook module should be installed");
+        // 2. Sign and request emergency uninstall
+        EmergencyUninstall memory emergencyUninstall = EmergencyUninstall({ hook: address(HOOK_MODULE), hookType: MODULE_TYPE_HOOK, deInitData: "", nonce: 0 });
 
-        uint256 prevTimeStamp = block.timestamp;
+        bytes32 hash = _hashTypedData(
+            keccak256(
+                abi.encode(
+                    EMERGENCY_UNINSTALL_TYPE_HASH,
+                    emergencyUninstall.hook,
+                    emergencyUninstall.hookType,
+                    keccak256(emergencyUninstall.deInitData),
+                    emergencyUninstall.nonce
+                )
+            ),
+            address(BOB_ACCOUNT)
+        );
 
+        bytes memory signature = abi.encodePacked(address(SIMPLE_VALIDATOR_MODULE), sign(BOB, hash));
 
+        bytes memory emergencyUninstallCalldata = abi.encodeWithSelector(Nexus.emergencyUninstallHook.selector, emergencyUninstall, signature);
 
-        // 2. Request to uninstall the hook
-        bytes memory emergencyUninstallCalldata = abi.encodeWithSelector(Nexus.emergencyUninstallHook.selector, address(HOOK_MODULE), "");
-
-        // Initialize the userOps array with one operation
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
-        userOps[0] = buildPackedUserOp(address(BOB_ACCOUNT), getNonce(address(BOB_ACCOUNT), MODE_VALIDATION, address(VALIDATOR_MODULE), bytes3(0)));
+        userOps[0] = buildPackedUserOp(address(BOB_ACCOUNT), getNonce(address(BOB_ACCOUNT), MODE_VALIDATION, address(SIMPLE_VALIDATOR_MODULE), bytes3(0)));
         userOps[0].callData = emergencyUninstallCalldata;
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
-        userOps[0].signature = signMessage(BOB, userOpHash);
+        userOps[0].signature = sign(BOB, userOpHash);
 
         vm.expectEmit(true, true, true, true);
         emit EmergencyHookUninstallRequest(address(HOOK_MODULE), block.timestamp);
 
         ENTRYPOINT.handleOps(userOps, payable(BOB.addr));
 
-
         // 3. Try without waiting for time to pass
+
+        // Rebuild the user operation
+        emergencyUninstall.nonce = 1;
+        hash = _hashTypedData(
+            keccak256(
+                abi.encode(
+                    EMERGENCY_UNINSTALL_TYPE_HASH,
+                    emergencyUninstall.hook,
+                    emergencyUninstall.hookType,
+                    keccak256(emergencyUninstall.deInitData),
+                    emergencyUninstall.nonce
+                )
+            ),
+            address(BOB_ACCOUNT)
+        );
+        signature = abi.encodePacked(address(SIMPLE_VALIDATOR_MODULE), sign(BOB, hash));
+        emergencyUninstallCalldata = abi.encodeWithSelector(Nexus.emergencyUninstallHook.selector, emergencyUninstall, signature);
+
         PackedUserOperation[] memory newUserOps = new PackedUserOperation[](1);
-        newUserOps[0] = buildPackedUserOp(address(BOB_ACCOUNT), getNonce(address(BOB_ACCOUNT), MODE_VALIDATION, address(VALIDATOR_MODULE), bytes3(0)));
+        newUserOps[0] = buildPackedUserOp(address(BOB_ACCOUNT), getNonce(address(BOB_ACCOUNT), MODE_VALIDATION, address(SIMPLE_VALIDATOR_MODULE), bytes3(0)));
         newUserOps[0].callData = emergencyUninstallCalldata;
         bytes32 newUserOpHash = ENTRYPOINT.getUserOpHash(newUserOps[0]);
-        newUserOps[0].signature = signMessage(BOB, newUserOpHash);
+        newUserOps[0].signature = sign(BOB, newUserOpHash);
 
         bytes memory expectedRevertReason = abi.encodeWithSelector(EmergencyTimeLockNotExpired.selector);
         // Expect the UserOperationRevertReason event
         vm.expectEmit(true, true, true, true);
-        emit UserOperationRevertReason(
-            newUserOpHash, // userOpHash
-            address(BOB_ACCOUNT), // sender
-            newUserOps[0].nonce, // nonce
-            expectedRevertReason
-        );
+        emit UserOperationRevertReason(newUserOpHash, address(BOB_ACCOUNT), newUserOps[0].nonce, expectedRevertReason);
         ENTRYPOINT.handleOps(newUserOps, payable(BOB.addr));
 
-        assertTrue(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""), "Hook MUST still be installed");
+        assertTrue(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""));
     }
 
     function test_EmergencyUninstallHook_Success_LongAfterInitiated() public {
         // 1. Install the hook
-
-        // Ensure the hook module is not installed initially
-        assertFalse(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""), "Hook module should not be installed initially");
-
-        // Prepare call data for installing the hook module
+        assertFalse(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""));
         bytes memory callData = abi.encodeWithSelector(IModuleManager.installModule.selector, MODULE_TYPE_HOOK, address(HOOK_MODULE), "");
-
-        // Install the hook module
         installModule(callData, MODULE_TYPE_HOOK, address(HOOK_MODULE), EXECTYPE_DEFAULT);
-
-        // Assert that the hook module is now installed
-        assertTrue(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""), "Hook module should be installed");
+        assertTrue(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""));
 
         uint256 prevTimeStamp = block.timestamp;
 
+        // 2. Sign and request emergency uninstall
+        EmergencyUninstall memory emergencyUninstall = EmergencyUninstall({ hook: address(HOOK_MODULE), hookType: MODULE_TYPE_HOOK, deInitData: "", nonce: 0 });
 
+        bytes32 hash = _hashTypedData(
+            keccak256(
+                abi.encode(
+                    EMERGENCY_UNINSTALL_TYPE_HASH,
+                    emergencyUninstall.hook,
+                    emergencyUninstall.hookType,
+                    keccak256(emergencyUninstall.deInitData),
+                    emergencyUninstall.nonce
+                )
+            ),
+            address(BOB_ACCOUNT)
+        );
 
-        // 2. Request to uninstall the hook
-        bytes memory emergencyUninstallCalldata = abi.encodeWithSelector(Nexus.emergencyUninstallHook.selector, address(HOOK_MODULE), "");
+        bytes memory signature = abi.encodePacked(address(SIMPLE_VALIDATOR_MODULE), sign(BOB, hash));
 
-        // Initialize the userOps array with one operation
+        bytes memory emergencyUninstallCalldata = abi.encodeWithSelector(Nexus.emergencyUninstallHook.selector, emergencyUninstall, signature);
+
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
-        userOps[0] = buildPackedUserOp(address(BOB_ACCOUNT), getNonce(address(BOB_ACCOUNT), MODE_VALIDATION, address(VALIDATOR_MODULE), bytes3(0)));
+        userOps[0] = buildPackedUserOp(address(BOB_ACCOUNT), getNonce(address(BOB_ACCOUNT), MODE_VALIDATION, address(SIMPLE_VALIDATOR_MODULE), bytes3(0)));
         userOps[0].callData = emergencyUninstallCalldata;
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
-        userOps[0].signature = signMessage(BOB, userOpHash);
+        userOps[0].signature = sign(BOB, userOpHash);
 
         vm.expectEmit(true, true, true, true);
         emit EmergencyHookUninstallRequest(address(HOOK_MODULE), block.timestamp);
 
         ENTRYPOINT.handleOps(userOps, payable(BOB.addr));
 
-
         // 3. Wait for time to pass
+
         // not more than 3 days
         vm.warp(prevTimeStamp + 2 days);
 
+        // Rebuild the user operation
+        emergencyUninstall.nonce = 1;
+        hash = _hashTypedData(
+            keccak256(
+                abi.encode(
+                    EMERGENCY_UNINSTALL_TYPE_HASH,
+                    emergencyUninstall.hook,
+                    emergencyUninstall.hookType,
+                    keccak256(emergencyUninstall.deInitData),
+                    emergencyUninstall.nonce
+                )
+            ),
+            address(BOB_ACCOUNT)
+        );
+        signature = abi.encodePacked(address(SIMPLE_VALIDATOR_MODULE), sign(BOB, hash));
+        emergencyUninstallCalldata = abi.encodeWithSelector(Nexus.emergencyUninstallHook.selector, emergencyUninstall, signature);
+
         PackedUserOperation[] memory newUserOps = new PackedUserOperation[](1);
-        newUserOps[0] = buildPackedUserOp(address(BOB_ACCOUNT), getNonce(address(BOB_ACCOUNT), MODE_VALIDATION, address(VALIDATOR_MODULE), bytes3(0)));
+        newUserOps[0] = buildPackedUserOp(address(BOB_ACCOUNT), getNonce(address(BOB_ACCOUNT), MODE_VALIDATION, address(SIMPLE_VALIDATOR_MODULE), bytes3(0)));
         newUserOps[0].callData = emergencyUninstallCalldata;
         bytes32 newUserOpHash = ENTRYPOINT.getUserOpHash(newUserOps[0]);
-        newUserOps[0].signature = signMessage(BOB, newUserOpHash);
-        // Expect the UserOperationRevertReason event
+        newUserOps[0].signature = sign(BOB, newUserOpHash);
+
         vm.expectEmit(true, true, true, true);
         emit ModuleUninstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE));
         ENTRYPOINT.handleOps(newUserOps, payable(BOB.addr));
 
-        assertFalse(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""), "Hook module should not be installed anymore");
+        assertFalse(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""));
     }
 
     function test_EmergencyUninstallHook_Success_Reset_SuperLongAfterInitiated() public {
         // 1. Install the hook
-
-        // Ensure the hook module is not installed initially
-        assertFalse(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""), "Hook module should not be installed initially");
-
-        // Prepare call data for installing the hook module
+        assertFalse(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""));
         bytes memory callData = abi.encodeWithSelector(IModuleManager.installModule.selector, MODULE_TYPE_HOOK, address(HOOK_MODULE), "");
-
-        // Install the hook module
         installModule(callData, MODULE_TYPE_HOOK, address(HOOK_MODULE), EXECTYPE_DEFAULT);
-
-        // Assert that the hook module is now installed
-        assertTrue(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""), "Hook module should be installed");
+        assertTrue(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""));
 
         uint256 prevTimeStamp = block.timestamp;
 
+        // 2. Sign and request emergency uninstall
+        EmergencyUninstall memory emergencyUninstall = EmergencyUninstall({ hook: address(HOOK_MODULE), hookType: MODULE_TYPE_HOOK, deInitData: "", nonce: 0 });
 
+        bytes32 hash = _hashTypedData(
+            keccak256(
+                abi.encode(
+                    EMERGENCY_UNINSTALL_TYPE_HASH,
+                    emergencyUninstall.hook,
+                    emergencyUninstall.hookType,
+                    keccak256(emergencyUninstall.deInitData),
+                    emergencyUninstall.nonce
+                )
+            ),
+            address(BOB_ACCOUNT)
+        );
 
-        // 2. Request to uninstall the hook
-        bytes memory emergencyUninstallCalldata = abi.encodeWithSelector(Nexus.emergencyUninstallHook.selector, address(HOOK_MODULE), "");
+        bytes memory signature = abi.encodePacked(address(SIMPLE_VALIDATOR_MODULE), sign(BOB, hash));
 
-        // Initialize the userOps array with one operation
+        bytes memory emergencyUninstallCalldata = abi.encodeWithSelector(Nexus.emergencyUninstallHook.selector, emergencyUninstall, signature);
+
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
-        userOps[0] = buildPackedUserOp(address(BOB_ACCOUNT), getNonce(address(BOB_ACCOUNT), MODE_VALIDATION, address(VALIDATOR_MODULE), 0));
+        userOps[0] = buildPackedUserOp(address(BOB_ACCOUNT), getNonce(address(BOB_ACCOUNT), MODE_VALIDATION, address(SIMPLE_VALIDATOR_MODULE), bytes3(0)));
         userOps[0].callData = emergencyUninstallCalldata;
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
-        userOps[0].signature = signMessage(BOB, userOpHash);
+        userOps[0].signature = sign(BOB, userOpHash);
 
         vm.expectEmit(true, true, true, true);
         emit EmergencyHookUninstallRequest(address(HOOK_MODULE), block.timestamp);
 
         ENTRYPOINT.handleOps(userOps, payable(BOB.addr));
 
-
         // 3. Wait for time to pass
+
         // more than 3 days
         vm.warp(prevTimeStamp + 4 days);
 
+        // Rebuild the user operation
+        emergencyUninstall.nonce = 1;
+        hash = _hashTypedData(
+            keccak256(
+                abi.encode(
+                    EMERGENCY_UNINSTALL_TYPE_HASH,
+                    emergencyUninstall.hook,
+                    emergencyUninstall.hookType,
+                    keccak256(emergencyUninstall.deInitData),
+                    emergencyUninstall.nonce
+                )
+            ),
+            address(BOB_ACCOUNT)
+        );
+        signature = abi.encodePacked(address(SIMPLE_VALIDATOR_MODULE), sign(BOB, hash));
+        emergencyUninstallCalldata = abi.encodeWithSelector(Nexus.emergencyUninstallHook.selector, emergencyUninstall, signature);
+
         PackedUserOperation[] memory newUserOps = new PackedUserOperation[](1);
-        newUserOps[0] = buildPackedUserOp(address(BOB_ACCOUNT), getNonce(address(BOB_ACCOUNT), MODE_VALIDATION, address(VALIDATOR_MODULE), 0));
+        newUserOps[0] = buildPackedUserOp(address(BOB_ACCOUNT), getNonce(address(BOB_ACCOUNT), MODE_VALIDATION, address(SIMPLE_VALIDATOR_MODULE), bytes3(0)));
         newUserOps[0].callData = emergencyUninstallCalldata;
         bytes32 newUserOpHash = ENTRYPOINT.getUserOpHash(newUserOps[0]);
-        newUserOps[0].signature = signMessage(BOB, newUserOpHash);
+        newUserOps[0].signature = sign(BOB, newUserOpHash);
 
-        // Expect the UserOperationRevertReason event
         vm.expectEmit(true, true, true, true);
         emit EmergencyHookUninstallRequestReset(address(HOOK_MODULE), block.timestamp);
         ENTRYPOINT.handleOps(newUserOps, payable(BOB.addr));
 
-        assertTrue(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""), "Hook module should still be installed");
+        assertTrue(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""));
     }
 
+    function test_EmergencyUninstallHook_DirectCall_Success() public {
+        // 1. Install the hook
+        assertFalse(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""));
+        bytes memory callData = abi.encodeWithSelector(IModuleManager.installModule.selector, MODULE_TYPE_HOOK, address(HOOK_MODULE), "");
+        installModule(callData, MODULE_TYPE_HOOK, address(HOOK_MODULE), EXECTYPE_DEFAULT);
+        assertTrue(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""));
+
+        // 2. Sign and request emergency uninstall
+        EmergencyUninstall memory emergencyUninstall = EmergencyUninstall({ hook: address(HOOK_MODULE), hookType: MODULE_TYPE_HOOK, deInitData: "", nonce: 0 });
+
+        bytes32 hash = _hashTypedData(
+            keccak256(
+                abi.encode(
+                    EMERGENCY_UNINSTALL_TYPE_HASH,
+                    emergencyUninstall.hook,
+                    emergencyUninstall.hookType,
+                    keccak256(emergencyUninstall.deInitData),
+                    emergencyUninstall.nonce
+                )
+            ),
+            address(BOB_ACCOUNT)
+        );
+
+        bytes memory signature = abi.encodePacked(address(SIMPLE_VALIDATOR_MODULE), sign(BOB, hash));
+
+        vm.prank(address(BOB_ACCOUNT));
+        vm.expectEmit(true, true, true, true);
+        emit EmergencyHookUninstallRequest(address(HOOK_MODULE), block.timestamp);
+
+        BOB_ACCOUNT.emergencyUninstallHook(emergencyUninstall, signature);
+
+        assertTrue(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""));
+    }
+
+    function test_EmergencyUninstallHook_DirectCall_Fail_WrongSigner() public {
+        // 1. Install the hook
+        assertFalse(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""));
+        bytes memory callData = abi.encodeWithSelector(IModuleManager.installModule.selector, MODULE_TYPE_HOOK, address(HOOK_MODULE), "");
+        installModule(callData, MODULE_TYPE_HOOK, address(HOOK_MODULE), EXECTYPE_DEFAULT);
+        assertTrue(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""));
+
+        // 2. Sign with wrong signer (ALICE instead of BOB)
+        EmergencyUninstall memory emergencyUninstall = EmergencyUninstall({ hook: address(HOOK_MODULE), hookType: MODULE_TYPE_HOOK, deInitData: "", nonce: 0 });
+
+        bytes32 hash = _hashTypedData(
+            keccak256(
+                abi.encode(
+                    EMERGENCY_UNINSTALL_TYPE_HASH,
+                    emergencyUninstall.hook,
+                    emergencyUninstall.hookType,
+                    keccak256(emergencyUninstall.deInitData),
+                    emergencyUninstall.nonce
+                )
+            ),
+            address(BOB_ACCOUNT)
+        );
+
+        bytes memory signature = abi.encodePacked(
+            address(SIMPLE_VALIDATOR_MODULE),
+            sign(ALICE, hash) // ALICE signs instead of BOB
+        );
+
+        vm.prank(address(BOB_ACCOUNT));
+        vm.expectRevert(EmergencyUninstallSigError.selector);
+        BOB_ACCOUNT.emergencyUninstallHook(emergencyUninstall, signature);
+
+        assertTrue(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), ""));
+    }
+
+    function test_EmergencyUninstallHook_1271_DirectCall_Success() public {
+        // 1. Install the 1271 hook
+        MockPreValidationHook preValidationHook = new MockPreValidationHook();
+        assertFalse(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_PREVALIDATION_HOOK_ERC1271, address(preValidationHook), ""));
+
+        bytes memory callData =
+            abi.encodeWithSelector(IModuleManager.installModule.selector, MODULE_TYPE_PREVALIDATION_HOOK_ERC1271, address(preValidationHook), "");
+        installModule(callData, MODULE_TYPE_PREVALIDATION_HOOK_ERC1271, address(preValidationHook), EXECTYPE_DEFAULT);
+        assertTrue(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_PREVALIDATION_HOOK_ERC1271, address(preValidationHook), ""));
+
+        // 2. Sign and request emergency uninstall
+        EmergencyUninstall memory emergencyUninstall =
+            EmergencyUninstall({ hook: address(preValidationHook), hookType: MODULE_TYPE_PREVALIDATION_HOOK_ERC1271, deInitData: "", nonce: 0 });
+
+        bytes32 hash = _hashTypedData(
+            keccak256(
+                abi.encode(
+                    EMERGENCY_UNINSTALL_TYPE_HASH,
+                    emergencyUninstall.hook,
+                    emergencyUninstall.hookType,
+                    keccak256(emergencyUninstall.deInitData),
+                    emergencyUninstall.nonce
+                )
+            ),
+            address(BOB_ACCOUNT)
+        );
+
+        bytes memory signature = abi.encodePacked(address(SIMPLE_VALIDATOR_MODULE), sign(BOB, hash));
+
+        vm.prank(address(BOB_ACCOUNT));
+        vm.expectEmit(true, true, true, true);
+        emit EmergencyHookUninstallRequest(address(preValidationHook), block.timestamp);
+        BOB_ACCOUNT.emergencyUninstallHook(emergencyUninstall, signature);
+
+        assertTrue(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_PREVALIDATION_HOOK_ERC1271, address(preValidationHook), ""));
+    }
+
+    function test_EmergencyUninstallHook_4337_DirectCall_Success() public {
+        // 1. Install the 4337 hook
+        MockPreValidationHook preValidationHook = new MockPreValidationHook();
+        assertFalse(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_PREVALIDATION_HOOK_ERC4337, address(preValidationHook), ""));
+
+        bytes memory callData =
+            abi.encodeWithSelector(IModuleManager.installModule.selector, MODULE_TYPE_PREVALIDATION_HOOK_ERC4337, address(preValidationHook), "");
+        installModule(callData, MODULE_TYPE_PREVALIDATION_HOOK_ERC4337, address(preValidationHook), EXECTYPE_DEFAULT);
+        assertTrue(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_PREVALIDATION_HOOK_ERC4337, address(preValidationHook), ""));
+
+        // 2. Sign and request emergency uninstall
+        EmergencyUninstall memory emergencyUninstall =
+            EmergencyUninstall({ hook: address(preValidationHook), hookType: MODULE_TYPE_PREVALIDATION_HOOK_ERC4337, deInitData: "", nonce: 0 });
+
+        bytes32 hash = _hashTypedData(
+            keccak256(
+                abi.encode(
+                    EMERGENCY_UNINSTALL_TYPE_HASH,
+                    emergencyUninstall.hook,
+                    emergencyUninstall.hookType,
+                    keccak256(emergencyUninstall.deInitData),
+                    emergencyUninstall.nonce
+                )
+            ),
+            address(BOB_ACCOUNT)
+        );
+
+        bytes memory signature = abi.encodePacked(address(SIMPLE_VALIDATOR_MODULE), sign(BOB, hash));
+
+        vm.prank(address(BOB_ACCOUNT));
+        vm.expectEmit(true, true, true, true);
+        emit EmergencyHookUninstallRequest(address(preValidationHook), block.timestamp);
+        BOB_ACCOUNT.emergencyUninstallHook(emergencyUninstall, signature);
+
+        assertTrue(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_PREVALIDATION_HOOK_ERC4337, address(preValidationHook), ""));
+    }
+
+    function test_EmergencyUninstallHook_1271_DirectCall_Fail_WrongSigner() public {
+        // 1. Install the 1271 hook
+        MockPreValidationHook preValidationHook = new MockPreValidationHook();
+        bytes memory callData =
+            abi.encodeWithSelector(IModuleManager.installModule.selector, MODULE_TYPE_PREVALIDATION_HOOK_ERC1271, address(preValidationHook), "");
+        installModule(callData, MODULE_TYPE_PREVALIDATION_HOOK_ERC1271, address(preValidationHook), EXECTYPE_DEFAULT);
+
+        // 2. Sign with wrong signer (ALICE instead of BOB)
+        EmergencyUninstall memory emergencyUninstall =
+            EmergencyUninstall({ hook: address(preValidationHook), hookType: MODULE_TYPE_PREVALIDATION_HOOK_ERC1271, deInitData: "", nonce: 0 });
+
+        bytes32 hash = _hashTypedData(
+            keccak256(
+                abi.encode(
+                    EMERGENCY_UNINSTALL_TYPE_HASH,
+                    emergencyUninstall.hook,
+                    emergencyUninstall.hookType,
+                    keccak256(emergencyUninstall.deInitData),
+                    emergencyUninstall.nonce
+                )
+            ),
+            address(BOB_ACCOUNT)
+        );
+
+        bytes memory signature = abi.encodePacked(
+            address(SIMPLE_VALIDATOR_MODULE),
+            sign(ALICE, hash) // ALICE signs instead of BOB
+        );
+
+        vm.prank(address(BOB_ACCOUNT));
+        vm.expectRevert(EmergencyUninstallSigError.selector);
+        BOB_ACCOUNT.emergencyUninstallHook(emergencyUninstall, signature);
+    }
+
+    function test_EmergencyUninstallHook_4337_DirectCall_Fail_WrongSigner() public {
+        // 1. Install the 4337 hook
+        MockPreValidationHook preValidationHook = new MockPreValidationHook();
+        bytes memory callData =
+            abi.encodeWithSelector(IModuleManager.installModule.selector, MODULE_TYPE_PREVALIDATION_HOOK_ERC4337, address(preValidationHook), "");
+        installModule(callData, MODULE_TYPE_PREVALIDATION_HOOK_ERC4337, address(preValidationHook), EXECTYPE_DEFAULT);
+
+        // 2. Sign with wrong signer (ALICE instead of BOB)
+        EmergencyUninstall memory emergencyUninstall =
+            EmergencyUninstall({ hook: address(preValidationHook), hookType: MODULE_TYPE_PREVALIDATION_HOOK_ERC4337, deInitData: "", nonce: 0 });
+
+        bytes32 hash = _hashTypedData(
+            keccak256(
+                abi.encode(
+                    EMERGENCY_UNINSTALL_TYPE_HASH,
+                    emergencyUninstall.hook,
+                    emergencyUninstall.hookType,
+                    keccak256(emergencyUninstall.deInitData),
+                    emergencyUninstall.nonce
+                )
+            ),
+            address(BOB_ACCOUNT)
+        );
+
+        bytes memory signature = abi.encodePacked(
+            address(SIMPLE_VALIDATOR_MODULE),
+            sign(ALICE, hash) // ALICE signs instead of BOB
+        );
+
+        vm.prank(address(BOB_ACCOUNT));
+        vm.expectRevert(EmergencyUninstallSigError.selector);
+        BOB_ACCOUNT.emergencyUninstallHook(emergencyUninstall, signature);
+    }
+
+    function test_EmergencyUninstallHook_PreValidation1271_Uninstall() public {
+        // 1. Install the 1271 hook
+        MockPreValidationHook preValidationHook = new MockPreValidationHook();
+        assertFalse(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_PREVALIDATION_HOOK_ERC1271, address(preValidationHook), ""));
+
+        bytes memory callData =
+            abi.encodeWithSelector(IModuleManager.installModule.selector, MODULE_TYPE_PREVALIDATION_HOOK_ERC1271, address(preValidationHook), "");
+        installModule(callData, MODULE_TYPE_PREVALIDATION_HOOK_ERC1271, address(preValidationHook), EXECTYPE_DEFAULT);
+        assertTrue(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_PREVALIDATION_HOOK_ERC1271, address(preValidationHook), ""));
+
+        // 2. Sign and request emergency uninstall
+        EmergencyUninstall memory emergencyUninstall =
+            EmergencyUninstall({ hook: address(preValidationHook), hookType: MODULE_TYPE_PREVALIDATION_HOOK_ERC1271, deInitData: "", nonce: 0 });
+
+        bytes32 hash = _hashTypedData(
+            keccak256(
+                abi.encode(
+                    EMERGENCY_UNINSTALL_TYPE_HASH,
+                    emergencyUninstall.hook,
+                    emergencyUninstall.hookType,
+                    keccak256(emergencyUninstall.deInitData),
+                    emergencyUninstall.nonce
+                )
+            ),
+            address(BOB_ACCOUNT)
+        );
+
+        bytes memory signature = abi.encodePacked(address(SIMPLE_VALIDATOR_MODULE), sign(BOB, hash));
+
+        uint256 prevTimeStamp = block.timestamp;
+
+        // Direct call to emergency uninstall
+        vm.expectEmit(true, true, true, true);
+        emit EmergencyHookUninstallRequest(address(preValidationHook), block.timestamp);
+        BOB_ACCOUNT.emergencyUninstallHook(emergencyUninstall, signature);
+
+        // Wait for time to pass
+        vm.warp(prevTimeStamp + 2 days);
+
+        // Rebuild the request
+        emergencyUninstall.nonce = 1;
+        hash = _hashTypedData(
+            keccak256(
+                abi.encode(
+                    EMERGENCY_UNINSTALL_TYPE_HASH,
+                    emergencyUninstall.hook,
+                    emergencyUninstall.hookType,
+                    keccak256(emergencyUninstall.deInitData),
+                    emergencyUninstall.nonce
+                )
+            ),
+            address(BOB_ACCOUNT)
+        );
+        signature = abi.encodePacked(address(SIMPLE_VALIDATOR_MODULE), sign(BOB, hash));
+
+        vm.expectEmit(true, true, true, true);
+        emit ModuleUninstalled(MODULE_TYPE_PREVALIDATION_HOOK_ERC1271, address(preValidationHook));
+        BOB_ACCOUNT.emergencyUninstallHook(emergencyUninstall, signature);
+
+        assertFalse(
+            BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_PREVALIDATION_HOOK_ERC1271, address(preValidationHook), ""),
+            "PreValidation 1271 hook should be uninstalled"
+        );
+    }
+
+    function test_EmergencyUninstallHook_PreValidation4337_Uninstall() public {
+        // 1. Install the 4337 hook
+        MockPreValidationHook preValidationHook = new MockPreValidationHook();
+        assertFalse(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_PREVALIDATION_HOOK_ERC4337, address(preValidationHook), ""));
+
+        bytes memory callData =
+            abi.encodeWithSelector(IModuleManager.installModule.selector, MODULE_TYPE_PREVALIDATION_HOOK_ERC4337, address(preValidationHook), "");
+        installModule(callData, MODULE_TYPE_PREVALIDATION_HOOK_ERC4337, address(preValidationHook), EXECTYPE_DEFAULT);
+        assertTrue(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_PREVALIDATION_HOOK_ERC4337, address(preValidationHook), ""));
+
+        // 2. Sign and request emergency uninstall
+        EmergencyUninstall memory emergencyUninstall =
+            EmergencyUninstall({ hook: address(preValidationHook), hookType: MODULE_TYPE_PREVALIDATION_HOOK_ERC4337, deInitData: "", nonce: 0 });
+
+        bytes32 hash = _hashTypedData(
+            keccak256(
+                abi.encode(
+                    EMERGENCY_UNINSTALL_TYPE_HASH,
+                    emergencyUninstall.hook,
+                    emergencyUninstall.hookType,
+                    keccak256(emergencyUninstall.deInitData),
+                    emergencyUninstall.nonce
+                )
+            ),
+            address(BOB_ACCOUNT)
+        );
+
+        bytes memory signature = abi.encodePacked(address(SIMPLE_VALIDATOR_MODULE), sign(BOB, hash));
+
+        uint256 prevTimeStamp = block.timestamp;
+
+        // Initiate uninstall request
+        vm.expectEmit(true, true, true, true);
+        emit EmergencyHookUninstallRequest(address(preValidationHook), block.timestamp);
+        BOB_ACCOUNT.emergencyUninstallHook(emergencyUninstall, signature);
+
+        // Wait for time to pass
+        vm.warp(prevTimeStamp + 2 days);
+
+        // Perform uninstall
+
+        // Rebuild the request
+        emergencyUninstall.nonce = 1;
+        hash = _hashTypedData(
+            keccak256(
+                abi.encode(
+                    EMERGENCY_UNINSTALL_TYPE_HASH,
+                    emergencyUninstall.hook,
+                    emergencyUninstall.hookType,
+                    keccak256(emergencyUninstall.deInitData),
+                    emergencyUninstall.nonce
+                )
+            ),
+            address(BOB_ACCOUNT)
+        );
+        signature = abi.encodePacked(address(SIMPLE_VALIDATOR_MODULE), sign(BOB, hash));
+
+        vm.expectEmit(true, true, true, true);
+        emit ModuleUninstalled(MODULE_TYPE_PREVALIDATION_HOOK_ERC4337, address(preValidationHook));
+        BOB_ACCOUNT.emergencyUninstallHook(emergencyUninstall, signature);
+
+        assertFalse(
+            BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_PREVALIDATION_HOOK_ERC4337, address(preValidationHook), ""),
+            "PreValidation 4337 hook should be uninstalled"
+        );
+    }
+
+    function sign(Vm.Wallet memory wallet, bytes32 hash) internal pure returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(wallet.privateKey, hash);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _hashTypedData(bytes32 structHash, address account) internal view virtual returns (bytes32 digest) {
+        // Get the domain separator
+        digest = buildDomainSeparator(account);
+
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Compute the digest.
+            mstore(0x00, 0x1901000000000000) // Store "\x19\x01".
+            mstore(0x1a, digest) // Store the domain separator.
+            mstore(0x3a, structHash) // Store the struct hash.
+            digest := keccak256(0x18, 0x42)
+            // Restore the part of the free memory slot that was overwritten.
+            mstore(0x3a, 0)
+        }
+    }
+
+    /// @notice Builds the domain separator for the account.
+    function buildDomainSeparator(address account) internal view returns (bytes32 separator) {
+        (, string memory name, string memory version,,,,) = EIP712(account).eip712Domain();
+
+        bytes32 _DOMAIN_TYPEHASH = 0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f;
+
+        // We will use `separator` to store the name hash to save a bit of gas.
+        bytes32 versionHash;
+        separator = keccak256(bytes(name));
+        versionHash = keccak256(bytes(version));
+
+        /// @solidity memory-safe-assembly
+        assembly {
+            let m := mload(0x40) // Load the free memory pointer.
+            mstore(m, _DOMAIN_TYPEHASH)
+            mstore(add(m, 0x20), separator) // Name hash.
+            mstore(add(m, 0x40), versionHash)
+            mstore(add(m, 0x60), chainid())
+            mstore(add(m, 0x80), account)
+            separator := keccak256(m, 0xa0)
+        }
+    }
 }

--- a/test/foundry/utils/EventsAndErrors.sol
+++ b/test/foundry/utils/EventsAndErrors.sol
@@ -43,10 +43,10 @@ contract EventsAndErrors {
     error InvalidFactoryAddress();
     error InvalidEntryPointAddress();
     error InnerCallFailed();
+    error EmergencyUninstallSigError();
     error CallToDeployWithFactoryFailed();
     error NexusInitializationFailed();
     error InvalidThreshold(uint8 providedThreshold, uint256 attestersCount);
-
 
     // ==========================
     // Operation Errors


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces new pre-validation hooks for ERC-1271 and ERC-4337, enhances error handling, and implements an emergency uninstall feature. It also adds related mock contracts for testing and updates the module management system to support these hooks.

### Detailed summary
- Added `EmergencyUninstall` struct for emergency uninstall data.
- Introduced new errors: `EmergencyUninstallSigError`, `InvalidNonce`, and `PrevalidationHookAlreadyInstalled`.
- Implemented pre-validation hooks for ERC-1271 and ERC-4337.
- Enhanced `ModuleManager` to manage pre-validation hooks.
- Updated `Nexus` contract to support emergency uninstall operations.
- Added `MockAccountLocker`, `MockPreValidationHook`, and other mock contracts for testing.
- Updated tests to cover new functionalities and error scenarios.

> The following files were skipped due to too many changes: `contracts/base/ModuleManager.sol`, `test/foundry/unit/concrete/hook/TestNexus_Hook_Emergency_Uninstall.sol`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->