### PR TITLE
add new method to k1

### DIFF
--- a/contracts/common/Stakeable.sol
+++ b/contracts/common/Stakeable.sol
@@ -28,33 +28,31 @@ contract Stakeable is Ownable, IStakeable {
     /// @notice Error thrown when an invalid EntryPoint address is provided.
     error InvalidEntryPointAddress();
 
-    constructor(address newOwner) {
+    address public immutable ENTRY_POINT;
+
+    constructor(address newOwner, address entryPoint) {
         _setOwner(newOwner);
+        require(entryPoint != address(0), InvalidEntryPointAddress());
+        ENTRY_POINT = entryPoint;
     }
 
     /// @notice Stakes a certain amount of Ether on an EntryPoint.
     /// @dev The contract should have enough Ether to cover the stake.
-    /// @param epAddress The address of the EntryPoint where the stake is added.
     /// @param unstakeDelaySec The delay in seconds before the stake can be unlocked.
-    function addStake(address epAddress, uint32 unstakeDelaySec) external payable onlyOwner {
-        require(epAddress != address(0), InvalidEntryPointAddress());
-        IEntryPoint(epAddress).addStake{ value: msg.value }(unstakeDelaySec);
+    function addStake(uint32 unstakeDelaySec) external payable onlyOwner {
+        IEntryPoint(ENTRY_POINT).addStake{ value: msg.value }(unstakeDelaySec);
     }
 
     /// @notice Unlocks the stake on an EntryPoint.
     /// @dev This starts the unstaking delay after which funds can be withdrawn.
-    /// @param epAddress The address of the EntryPoint from which the stake is to be unlocked.
-    function unlockStake(address epAddress) external onlyOwner {
-        require(epAddress != address(0), InvalidEntryPointAddress());
-        IEntryPoint(epAddress).unlockStake();
+    function unlockStake() external onlyOwner {
+        IEntryPoint(ENTRY_POINT).unlockStake();
     }
 
     /// @notice Withdraws the stake from an EntryPoint to a specified address.
     /// @dev This can only be done after the unstaking delay has passed since the unlock.
-    /// @param epAddress The address of the EntryPoint where the stake is withdrawn from.
     /// @param withdrawAddress The address to receive the withdrawn stake.
-    function withdrawStake(address epAddress, address payable withdrawAddress) external onlyOwner {
-        require(epAddress != address(0), InvalidEntryPointAddress());
-        IEntryPoint(epAddress).withdrawStake(withdrawAddress);
+    function withdrawStake(address payable withdrawAddress) external onlyOwner {
+        IEntryPoint(ENTRY_POINT).withdrawStake(withdrawAddress);
     }
 }

--- a/contracts/factory/BiconomyMetaFactory.sol
+++ b/contracts/factory/BiconomyMetaFactory.sol
@@ -43,7 +43,7 @@ contract BiconomyMetaFactory is Stakeable {
 
     /// @notice Constructor to set the owner of the contract.
     /// @param owner_ The address of the owner.
-    constructor(address owner_) Stakeable(owner_) {
+    constructor(address owner_, address entryPoint) Stakeable(owner_, entryPoint) {
         require(owner_ != address(0), ZeroAddressNotAllowed());
     }
 

--- a/contracts/factory/NexusAccountFactory.sol
+++ b/contracts/factory/NexusAccountFactory.sol
@@ -31,7 +31,7 @@ contract NexusAccountFactory is Stakeable, INexusFactory {
     /// @notice Constructor to set the smart account implementation address and the factory owner.
     /// @param implementation_ The address of the Nexus implementation to be used for all deployments.
     /// @param owner_ The address of the owner of the factory.
-    constructor(address implementation_, address owner_) Stakeable(owner_) {
+    constructor(address implementation_, address owner_, address entryPoint) Stakeable(owner_, entryPoint) {
         require(implementation_ != address(0), ImplementationAddressCanNotBeZero());
         require(owner_ != address(0), ZeroAddressNotAllowed());
         ACCOUNT_IMPLEMENTATION = implementation_;

--- a/contracts/factory/RegistryFactory.sol
+++ b/contracts/factory/RegistryFactory.sol
@@ -49,7 +49,9 @@ contract RegistryFactory is Stakeable, INexusFactory {
     /// @notice Constructor to set the smart account implementation address and owner.
     /// @param implementation_ The address of the Nexus implementation to be used for all deployments.
     /// @param owner_ The address of the owner of the factory.
-    constructor(address implementation_, address owner_, IERC7484 registry_, address[] memory attesters_, uint8 threshold_) Stakeable(owner_) {
+    constructor(address implementation_, address owner_, address entryPoint, IERC7484 registry_, address[] memory attesters_, uint8 threshold_)
+        Stakeable(owner_, entryPoint)
+    {
         require(implementation_ != address(0), ImplementationAddressCanNotBeZero());
         require(owner_ != address(0), ZeroAddressNotAllowed());
         require(threshold_ <= attesters_.length, InvalidThreshold(threshold_, attesters_.length));

--- a/contracts/interfaces/common/IStakeable.sol
+++ b/contracts/interfaces/common/IStakeable.sol
@@ -23,18 +23,15 @@ pragma solidity ^0.8.27;
 interface IStakeable {
     /// @notice Stakes a certain amount of Ether on an EntryPoint.
     /// @dev The contract should have enough Ether to cover the stake.
-    /// @param epAddress The address of the EntryPoint where the stake is added.
     /// @param unstakeDelaySec The delay in seconds before the stake can be unlocked.
-    function addStake(address epAddress, uint32 unstakeDelaySec) external payable;
+    function addStake(uint32 unstakeDelaySec) external payable;
 
     /// @notice Unlocks the stake on an EntryPoint.
     /// @dev This starts the unstaking delay after which funds can be withdrawn.
-    /// @param epAddress The address of the EntryPoint from which the stake is to be unlocked.
-    function unlockStake(address epAddress) external;
+    function unlockStake() external;
 
     /// @notice Withdraws the stake from an EntryPoint to a specified address.
     /// @dev This can only be done after the unstaking delay has passed since the unlock.
-    /// @param epAddress The address of the EntryPoint where the stake is withdrawn from.
     /// @param withdrawAddress The address to receive the withdrawn stake.
-    function withdrawStake(address epAddress, address payable withdrawAddress) external;
+    function withdrawStake(address payable withdrawAddress) external;
 }


### PR DESCRIPTION
Add front-run protected method to K1 Factory
as per https://github.com/eth-infinitism/account-abstraction/pull/514/files#diff-63e48c2a9557cb30a347e1b089b19a170f42ca42990a55ba1a226f2e58600120

It is expected that wallets use that method in the `userOp.initcode` if they want to protect against front-run => the whole userOp is reverted. 
The original non permissioned method is available for direct (non 4337 flow) deployments

- [ ] Fix other factories
- [ ] Update `eth-infinitism` dependency and fix tests as soon as new EP 0.8 is released with the EP.senderCreator method available

quote from EF:
=========
Prevent initcode front-run (AA-466)
In prior versions, the initCode from a UserOp can be extracted from a UserOp in the mempool, and executed by front-running the actual UserOp. The result is that the attacker pays for the account deployment, instead of the account owner.
Why is this a problem? Because wallets usually don’t expect a submitted UserOperation to fail, and require to re-submit (and re-sign) it.
In order to prevent such front-run, an account’s factory contract now could do
require(msg.sender == entryPoint.senderCreator());
(As can be seen in the SimpleAccountFactory)
Note: wallets are not required to use this method, but if they don’t, they are encouraged to protect their users against such a front-run.
====