### PR TITLE
Make Module Enable Mode compatible with 7702

### DIFF
--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -123,7 +123,7 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
                 validationData = IValidator(validator).validateUserOp(userOp, userOpHash);
             } else {
                 // If the account is not initialized, check the signature against the account
-                if (!_isAlreadyInitialized()) {
+                if (!_hasValidators() && !_hasExecutors()) {
                     // Check the userOp signature if the validator is not installed (used for EIP7702)
                     validationData = _checkSelfSignature(op.signature, userOpHash) ? VALIDATION_SUCCESS : VALIDATION_FAILED;
                 } else {

--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -46,7 +46,6 @@ import {
 } from "./lib/ModeLib.sol";
 import { NonceLib } from "./lib/NonceLib.sol";
 import { SentinelListLib, SENTINEL, ZERO_ADDRESS } from "sentinellist/SentinelList.sol";
-import { ECDSA } from "solady/utils/ECDSA.sol";
 import { Initializable } from "./lib/Initializable.sol";
 import { EmergencyUninstall } from "./types/DataTypes.sol";
 
@@ -63,7 +62,6 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
     using ExecLib for bytes;
     using NonceLib for uint256;
     using SentinelListLib for SentinelListLib.SentinelList;
-    using ECDSA for bytes32;
 
     /// @dev The timelock period for emergency hook uninstallation.
     uint256 internal constant _EMERGENCY_TIMELOCK = 1 days;
@@ -127,7 +125,7 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
                 // If the account is not initialized, check the signature against the account
                 if (!_isAlreadyInitialized()) {
                     // Check the userOp signature if the validator is not installed (used for EIP7702)
-                    validationData = _checkUserOpSignature(op.signature, userOpHash);
+                    validationData = _checkSelfSignature(op.signature, userOpHash) ? VALIDATION_SUCCESS : VALIDATION_FAILED;
                 } else {
                     // If the account is initialized, revert as the validator is not installed
                     revert ValidatorNotInstalled(validator);
@@ -312,7 +310,6 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
             }
         }
         // else proceed with normal signature verification
-
         // First 20 bytes of data will be validator address and rest of the bytes is complete signature.
         address validator = address(bytes20(signature[0:20]));
         require(_isValidatorInstalled(validator), ValidatorNotInstalled(validator));
@@ -438,19 +435,6 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
     /// This is part of the UUPS (Universal Upgradeable Proxy Standard) pattern.
     /// @param newImplementation The address of the new implementation to upgrade to.
     function _authorizeUpgrade(address newImplementation) internal virtual override(UUPSUpgradeable) onlyEntryPointOrSelf { }
-
-    /// @dev Checks if the userOp signer matches address(this), returns VALIDATION_SUCCESS if it does, otherwise VALIDATION_FAILED
-    /// @param signature The signature to check.
-    /// @param userOpHash The hash of the user operation data.
-    /// @return The validation result.
-    function _checkUserOpSignature(bytes calldata signature, bytes32 userOpHash) internal view returns (uint256) {
-        // Recover the signer from the signature, if it is the account, return success, otherwise revert
-        address signer = ECDSA.recover(userOpHash.toEthSignedMessageHash(), signature);
-        if (signer == address(this)) {
-            return VALIDATION_SUCCESS;
-        }
-        return VALIDATION_FAILED;
-    }
 
     /// @dev EIP712 domain name and version.
     function _domainNameAndVersion() internal pure override returns (string memory name, string memory version) {

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -467,7 +467,7 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
             }
         } else {
             // If the account is not initialized, check the signature against the account
-            if (!_isAlreadyInitialized()) {
+            if (!_hasValidators() && !_hasExecutors()) {
                 // ERC-7739 is not required here as the userOpHash is hashed into the structHash => safe
                 return _checkSelfSignature(sig, eip712Digest);
             } else {

--- a/test/foundry/fork/base/BaseSettings.t.sol
+++ b/test/foundry/fork/base/BaseSettings.t.sol
@@ -8,8 +8,8 @@ import "../../utils/NexusTest_Base.t.sol";
 contract BaseSettings is NexusTest_Base {
     address public constant UNISWAP_V2_ROUTER02 = 0x4752ba5DBc23f44D87826276BF6Fd6b1C372aD24;
     address public constant USDC_ADDRESS = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913;
-    string public constant DEFAULT_BASE_RPC_URL = "https://mainnet.base.org";
-    //string public constant DEFAULT_BASE_RPC_URL = "https://base.llamarpc.com";
+    //string public constant DEFAULT_BASE_RPC_URL = "https://mainnet.base.org";
+    string public constant DEFAULT_BASE_RPC_URL = "https://base.llamarpc.com";
     //string public constant DEFAULT_BASE_RPC_URL = "https://developer-access-mainnet.base.org";
     uint constant BLOCK_NUMBER = 15000000;
 

--- a/test/foundry/utils/TestHelper.t.sol
+++ b/test/foundry/utils/TestHelper.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+
+import "forge-std/console2.sol";
 import "solady/utils/ECDSA.sol";
 import "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import { EntryPoint } from "account-abstraction/core/EntryPoint.sol";
@@ -323,8 +325,9 @@ contract TestHelper is CheatCodes, EventsAndErrors {
     /// @param messageHash The hash of the message to sign
     /// @return signature The packed signature
     function signMessage(Vm.Wallet memory wallet, bytes32 messageHash) internal pure returns (bytes memory signature) {
-        bytes32 userOpHash = ECDSA.toEthSignedMessageHash(messageHash);
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(wallet.privateKey, userOpHash);
+        messageHash = ECDSA.toEthSignedMessageHash(messageHash);
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(wallet.privateKey, messageHash);
         signature = abi.encodePacked(r, s, v);
     }
 


### PR DESCRIPTION
- Module Enable Mode can verify enable sig from account itself (similar to validateUserOp)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the functionality and security of the `Nexus` contract and related modules, particularly for EIP-7702 accounts. It introduces new mechanisms for handling user operations and improves signature validation processes.

### Detailed summary
- Updated `DEFAULT_BASE_RPC_URL` in `BaseSettings.t.sol`.
- Refactored signature handling in `TestHelper` contract.
- Added tests for enabling modes in `TestModuleManager_EnableMode.t.sol`.
- Improved validation checks in `Nexus` contract, including `_hasValidators()` and `_hasExecutors()`.
- Replaced `_checkUserOpSignature` with `_checkSelfSignature` for better validation.
- Added initialization checks for validators and executors in `ModuleManager`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->