### PR TITLE
Prepare for EIP-712 userOpHash

### DIFF
--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -599,9 +599,10 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
     /// @return The validation result.
     function _checkSelfSignature(bytes calldata signature, bytes32 dataHash) internal view returns (bool) {
         // Recover the signer from the signature, if it is the account, return success, otherwise revert
-        address signer = ECDSA.recover(dataHash.toEthSignedMessageHash(), signature);
+        // toEthSignedMessageHash() is now considered fallback as userOpHash is eip-712 since ep v0.8
+        address signer = ECDSA.recover(dataHash, signature);
         if (signer == address(this)) return true;
-        signer = ECDSA.recover(dataHash, signature);
+        signer = ECDSA.recover(dataHash.toEthSignedMessageHash(), signature);
         if (signer == address(this)) return true;
         return false;
     }

--- a/contracts/mocks/MockMultiModule.sol
+++ b/contracts/mocks/MockMultiModule.sol
@@ -14,7 +14,17 @@ contract MockMultiModule is IModule {
 
     function validateUserOp(PackedUserOperation calldata userOp, bytes32 userOpHash) external view returns (uint256 validation) {
         address owner = address(bytes20(configs[MODULE_TYPE_VALIDATOR][msg.sender]));
-        return ECDSA.recover(MessageHashUtils.toEthSignedMessageHash(userOpHash), userOp.signature) == owner ? VALIDATION_SUCCESS : VALIDATION_FAILED;
+        return _checkSignature(owner, userOpHash, userOp.signature) ? VALIDATION_SUCCESS : VALIDATION_FAILED;
+    }
+
+    function _checkSignature(address owner, bytes32 userOpHash, bytes calldata signature) internal view returns (bool) {
+        if (ECDSA.recover(userOpHash, signature) == owner) {
+            return true;
+        }
+        if (ECDSA.recover(MessageHashUtils.toEthSignedMessageHash(userOpHash), signature) == owner) {
+            return true;
+        } 
+        return false;
     }
 
     function getConfig(address smartAccount, uint256 moduleTypeId) external view returns (bytes32) {

--- a/contracts/modules/validators/K1Validator.sol
+++ b/contracts/modules/validators/K1Validator.sol
@@ -245,6 +245,7 @@ contract K1Validator is IValidator, ERC7739Validator {
         // verify signer
         // owner can not be zero address in this contract
         if (_recoverSigner(hash, signature) == owner) return true;
+        // toEthSignedMessageHash() is now considered fallback as userOpHash is eip-712 since ep v0.8
         if (_recoverSigner(hash.toEthSignedMessageHash(), signature) == owner) return true;
         return false;
     }

--- a/test/foundry/fork/arbitrum/ArbitrumSmartAccountUpgradeTest.t.sol
+++ b/test/foundry/fork/arbitrum/ArbitrumSmartAccountUpgradeTest.t.sol
@@ -128,7 +128,7 @@ contract ArbitrumSmartAccountUpgradeTest is NexusTest_Base, ArbitrumSettings {
         userOps[0] = buildUserOperation(address(smartAccountV2), batchCallData);
 
         bytes32 userOpHash = ENTRYPOINT_V_0_6.getUserOpHash(userOps[0]);
-        userOps[0].signature = abi.encode(signMessage(signer, userOpHash), MODULE_ADDRESS);
+        userOps[0].signature = abi.encode(signPureHash(signer, userOpHash), MODULE_ADDRESS);
 
         ENTRYPOINT_V_0_6.handleOps(userOps, address(this));
     }

--- a/test/foundry/integration/TestNexusPreValidation_Integration_ResourceLockHooks.t.sol
+++ b/test/foundry/integration/TestNexusPreValidation_Integration_ResourceLockHooks.t.sol
@@ -69,7 +69,7 @@ contract TestNexusPreValidation_Integration_ResourceLockHooks is TestModuleManag
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
 
         // Sign the user operation
-        userOps[0].signature = signMessage(BOB, userOpHash);
+        userOps[0].signature = signPureHash(BOB, userOpHash);
 
         // Expect revert due to insufficient unlocked ETH
         vm.expectRevert(abi.encodeWithSelector(MockResourceLockPreValidationHook.InsufficientUnlockedETH.selector, missingAccountFunds));
@@ -107,7 +107,7 @@ contract TestNexusPreValidation_Integration_ResourceLockHooks is TestModuleManag
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
 
         // Sign the user operation
-        userOps[0].signature = signMessage(BOB, userOpHash);
+        userOps[0].signature = signPureHash(BOB, userOpHash);
 
         // Attempt to validate the user operation when unlocked balance is sufficient
         vm.assume(totalBalance - lockedAmount >= 0);

--- a/test/foundry/unit/concrete/accountexecution/TestAccountExecution_DelegateCall.t.sol
+++ b/test/foundry/unit/concrete/accountexecution/TestAccountExecution_DelegateCall.t.sol
@@ -50,7 +50,7 @@ contract TestAccountExecution_TryExecuteSingle is TestAccountExecution_Base {
 
         // Sign the operation
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
-        userOps[0].signature = signMessage(BOB, userOpHash);
+        userOps[0].signature = signPureHash(BOB, userOpHash);
 
         ENTRYPOINT.handleOps(userOps, payable(address(BOB.addr)));
          // Assert that the value was set ie that execution was successful
@@ -94,7 +94,7 @@ contract TestAccountExecution_TryExecuteSingle is TestAccountExecution_Base {
 
         // Sign the operation
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
-        userOps[0].signature = signMessage(BOB, userOpHash);
+        userOps[0].signature = signPureHash(BOB, userOpHash);
 
         ENTRYPOINT.handleOps(userOps, payable(address(BOB.addr)));
          // Assert that the value was set ie that execution was successful

--- a/test/foundry/unit/concrete/accountexecution/TestAccountExecution_ExecuteBatch.t.sol
+++ b/test/foundry/unit/concrete/accountexecution/TestAccountExecution_ExecuteBatch.t.sol
@@ -205,7 +205,7 @@ contract TestAccountExecution_ExecuteBatch is TestAccountExecution_Base {
 
         // Sign the operation
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
-        userOps[0].signature = signMessage(BOB, userOpHash);
+        userOps[0].signature = signPureHash(BOB, userOpHash);
 
         bytes memory expectedRevertReason = abi.encodeWithSelector(UnsupportedExecType.selector, unsupportedExecType);
 

--- a/test/foundry/unit/concrete/accountexecution/TestAccountExecution_ExecuteSingle.t.sol
+++ b/test/foundry/unit/concrete/accountexecution/TestAccountExecution_ExecuteSingle.t.sol
@@ -207,7 +207,7 @@ contract TestAccountExecution_ExecuteSingle is TestAccountExecution_Base {
 
         // Sign the operation
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
-        userOps[0].signature = signMessage(BOB, userOpHash);
+        userOps[0].signature = signPureHash(BOB, userOpHash);
 
         bytes memory expectedRevertReason = abi.encodeWithSelector(UnsupportedExecType.selector, unsupportedExecType);
 

--- a/test/foundry/unit/concrete/accountexecution/TestAccountExecution_ExecuteUserOp.t.sol
+++ b/test/foundry/unit/concrete/accountexecution/TestAccountExecution_ExecuteUserOp.t.sol
@@ -35,7 +35,7 @@ contract TestAccountExecution_ExecuteUserOp is TestAccountExecution_Base {
 
         // Sign the operation
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOp);
-        bytes memory signature = signMessage(BOB, userOpHash);
+        bytes memory signature = signPureHash(BOB, userOpHash);
         userOp.signature = signature;
 
         // Prepare the user operations array
@@ -66,7 +66,7 @@ contract TestAccountExecution_ExecuteUserOp is TestAccountExecution_Base {
 
         // Sign the operation
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOp);
-        bytes memory signature = signMessage(BOB, userOpHash);
+        bytes memory signature = signPureHash(BOB, userOpHash);
         userOp.signature = signature;
 
         // Prepare the user operations array
@@ -94,7 +94,7 @@ contract TestAccountExecution_ExecuteUserOp is TestAccountExecution_Base {
 
         // Sign the operation
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOp);
-        bytes memory signature = signMessage(BOB, userOpHash);
+        bytes memory signature = signPureHash(BOB, userOpHash);
         userOp.signature = signature;
 
         // Prepare the user operations array

--- a/test/foundry/unit/concrete/accountexecution/TestAccountExecution_TryExecuteSingle.t.sol
+++ b/test/foundry/unit/concrete/accountexecution/TestAccountExecution_TryExecuteSingle.t.sol
@@ -175,7 +175,7 @@ contract TestAccountExecution_TryExecuteSingle is TestAccountExecution_Base {
 
         // Sign the operation
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
-        userOps[0].signature = signMessage(BOB, userOpHash);
+        userOps[0].signature = signPureHash(BOB, userOpHash);
 
         // Expect the TryDelegateCallUnsuccessful event to be emitted
         vm.expectEmit(true, true, true, true);

--- a/test/foundry/unit/concrete/erc4337account/TestERC4337Account_OnlyEntryPoint.t.sol
+++ b/test/foundry/unit/concrete/erc4337account/TestERC4337Account_OnlyEntryPoint.t.sol
@@ -23,7 +23,7 @@ contract TestERC4337Account_OnlyEntryPoint is NexusTest_Base {
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = buildPackedUserOp(userAddress, getNonce(address(BOB_ACCOUNT), MODE_VALIDATION, address(VALIDATOR_MODULE), bytes3(0)));
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
-        userOps[0].signature = signMessage(BOB, userOpHash); // Sign operation with valid signer
+        userOps[0].signature = signPureHash(BOB, userOpHash); // Sign operation with valid signer
 
         startPrank(address(ENTRYPOINT));
         // Attempt to validate the user operation, expecting success
@@ -38,7 +38,7 @@ contract TestERC4337Account_OnlyEntryPoint is NexusTest_Base {
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = buildPackedUserOp(userAddress, getNonce(address(BOB_ACCOUNT), MODE_VALIDATION, address(VALIDATOR_MODULE), bytes3(0)));
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
-        userOps[0].signature = signMessage(ALICE, userOpHash); // Incorrect signer simulated
+        userOps[0].signature = signPureHash(ALICE, userOpHash); // Incorrect signer simulated
 
         startPrank(address(ENTRYPOINT));
         // Attempt to validate the user operation, expecting failure due to invalid signature
@@ -53,7 +53,7 @@ contract TestERC4337Account_OnlyEntryPoint is NexusTest_Base {
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = buildPackedUserOp(userAddress, getNonce(address(BOB_ACCOUNT), MODE_VALIDATION, address(VALIDATOR_MODULE), bytes3(0)));
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
-        userOps[0].signature = signMessage(BOB, userOpHash); // Still correctly signed
+        userOps[0].signature = signPureHash(BOB, userOpHash); // Still correctly signed
 
         startPrank(address(BOB_ACCOUNT));
         vm.expectRevert(abi.encodeWithSelector(AccountAccessUnauthorized.selector));
@@ -66,7 +66,7 @@ contract TestERC4337Account_OnlyEntryPoint is NexusTest_Base {
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = buildPackedUserOp(userAddress, getNonce(address(BOB_ACCOUNT), MODE_VALIDATION, address(VALIDATOR_MODULE), bytes3(0)));
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
-        userOps[0].signature = signMessage(ALICE, userOpHash); // Incorrect signer
+        userOps[0].signature = signPureHash(ALICE, userOpHash); // Incorrect signer
 
         startPrank(address(ENTRYPOINT));
         uint256 res = BOB_ACCOUNT.validateUserOp(userOps[0], userOpHash, 0);

--- a/test/foundry/unit/concrete/erc4337account/TestERC4337Account_PayPrefund.t.sol
+++ b/test/foundry/unit/concrete/erc4337account/TestERC4337Account_PayPrefund.t.sol
@@ -28,7 +28,7 @@ contract TestERC4337Account_PayPrefund is NexusTest_Base {
         // Build a packed user operation
         PackedUserOperation[] memory userOps = buildPackedUserOperation(signer, account, EXECTYPE_TRY, executions, address(VALIDATOR_MODULE), 0);
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
-        userOps[0].signature = signMessage(signer, userOpHash);
+        userOps[0].signature = signPureHash(signer, userOpHash);
 
         startPrank(address(ENTRYPOINT));
         account.validateUserOp(userOps[0], userOpHash, 0.1 ether);

--- a/test/foundry/unit/concrete/erc4337account/TestERC4337Account_ValidateUserOp.t.sol
+++ b/test/foundry/unit/concrete/erc4337account/TestERC4337Account_ValidateUserOp.t.sol
@@ -24,7 +24,7 @@ contract TestERC4337Account_ValidateUserOp is Test, NexusTest_Base {
         Execution[] memory executions = prepareSingleExecution(address(account), 0, "");
         PackedUserOperation[] memory userOps = buildPackedUserOperation(signer, account, EXECTYPE_TRY, executions, address(VALIDATOR_MODULE), 0);
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
-        userOps[0].signature = signMessage(signer, userOpHash);
+        userOps[0].signature = signPureHash(signer, userOpHash);
 
         startPrank(address(ENTRYPOINT));
         account.validateUserOp(userOps[0], userOpHash, 0.1 ether);
@@ -36,7 +36,7 @@ contract TestERC4337Account_ValidateUserOp is Test, NexusTest_Base {
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = buildPackedUserOp(signer.addr, getNonce(address(BOB_ACCOUNT), MODE_VALIDATION, address(VALIDATOR_MODULE), bytes3(0)));
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
-        userOps[0].signature = signMessage(BOB, userOpHash);
+        userOps[0].signature = signPureHash(BOB, userOpHash);
 
         startPrank(address(ENTRYPOINT));
         uint256 res = BOB_ACCOUNT.validateUserOp(userOps[0], userOpHash, 0);
@@ -49,7 +49,7 @@ contract TestERC4337Account_ValidateUserOp is Test, NexusTest_Base {
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = buildPackedUserOp(signer.addr, getNonce(address(BOB_ACCOUNT), MODE_VALIDATION, address(VALIDATOR_MODULE), bytes3(0)));
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
-        userOps[0].signature = signMessage(ALICE, userOpHash);
+        userOps[0].signature = signPureHash(ALICE, userOpHash);
 
         startPrank(address(ENTRYPOINT));
         uint256 res = BOB_ACCOUNT.validateUserOp(userOps[0], userOpHash, 0);
@@ -75,7 +75,7 @@ contract TestERC4337Account_ValidateUserOp is Test, NexusTest_Base {
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = buildPackedUserOp(signer.addr, getNonce(address(BOB_ACCOUNT), MODE_VALIDATION, address(VALIDATOR_MODULE), bytes3(0)));
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
-        userOps[0].signature = signMessage(BOB, userOpHash);
+        userOps[0].signature = signPureHash(BOB, userOpHash);
 
         startPrank(address(ENTRYPOINT));
         BOB_ACCOUNT.validateUserOp(userOps[0], userOpHash, 0.5 ether);

--- a/test/foundry/unit/concrete/modulemanager/TestModuleManager_EnableMode.t.sol
+++ b/test/foundry/unit/concrete/modulemanager/TestModuleManager_EnableMode.t.sol
@@ -40,11 +40,11 @@ contract TestModuleManager_EnableMode is Test, TestModuleManagement_Base {
         PackedUserOperation memory op = makeDraftOp(opValidator);
         
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(op);
-        op.signature = signMessage(ALICE, userOpHash);  // SIGN THE USEROP WITH SIGNER THAT IS ABOUT TO BE USED
+        op.signature = signPureHash(ALICE, userOpHash);  // SIGN THE USEROP WITH SIGNER THAT IS ABOUT TO BE USED
 
         (bytes memory multiInstallData, bytes32 hashToSign, ) = makeInstallDataAndHash(address(BOB_ACCOUNT), MODULE_TYPE_MULTI, userOpHash);
 
-        bytes memory enableModeSig = signMessage(BOB, hashToSign); //should be signed by current owner
+        bytes memory enableModeSig = signPureHash(BOB, hashToSign); //should be signed by current owner
         enableModeSig = abi.encodePacked(address(VALIDATOR_MODULE), enableModeSig); //append validator address
         // Enable Mode Sig Prefix
         // address moduleToEnable
@@ -94,14 +94,14 @@ contract TestModuleManager_EnableMode is Test, TestModuleManagement_Base {
         );
         
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(op);
-        op.signature = signMessage(ALICE, userOpHash);  // SIGN THE USEROP WITH SIGNER THAT IS ABOUT TO BE USED
+        op.signature = signPureHash(ALICE, userOpHash);  // SIGN THE USEROP WITH SIGNER THAT IS ABOUT TO BE USED
 
         // simulate uninitialized 7702 account
         vm.etch(BOB_ADDRESS, address(ACCOUNT_IMPLEMENTATION).code);
 
         (bytes memory multiInstallData, bytes32 hashToSign, ) = makeInstallDataAndHash(BOB_ADDRESS, MODULE_TYPE_MULTI, userOpHash);
 
-        bytes memory enableModeSig = signMessage(BOB, hashToSign); //should be signed by current owner
+        bytes memory enableModeSig = signPureHash(BOB, hashToSign); //should be signed by current owner
         //skip appending validator address, as it is not installed (emulate uninitialized 7702 account)
 
         bytes memory enableModeSigPrefix = abi.encodePacked(
@@ -138,7 +138,7 @@ contract TestModuleManager_EnableMode is Test, TestModuleManagement_Base {
         PackedUserOperation memory op = makeDraftOp(opValidator);
         
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(op);
-        op.signature = signMessage(ALICE, userOpHash);  // SIGN THE USEROP WITH SIGNER THAT IS ABOUT TO BE USED
+        op.signature = signPureHash(ALICE, userOpHash);  // SIGN THE USEROP WITH SIGNER THAT IS ABOUT TO BE USED
 
         (bytes memory multiInstallData, /*bytes32 eip712ChildHash*/, bytes32 structHash) = makeInstallDataAndHash(address(BOB_ACCOUNT), MODULE_TYPE_MULTI, userOpHash);
 
@@ -211,7 +211,7 @@ contract TestModuleManager_EnableMode is Test, TestModuleManagement_Base {
         );
 
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOp);
-        userOp.signature = signMessage(ALICE, userOpHash);  // SIGN THE USEROP WITH SIGNER THAT IS ABOUT TO BE USED VIA NEWLY INSTALLED (VIA ENABLE MODE) MODULE
+        userOp.signature = signPureHash(ALICE, userOpHash);  // SIGN THE USEROP WITH SIGNER THAT IS ABOUT TO BE USED VIA NEWLY INSTALLED (VIA ENABLE MODE) MODULE
 
         // since the account is not deployed yet, we can't get eip712 domain from it
         // so we take the structHash and manually convert it to proper 712 typed data hash
@@ -249,7 +249,7 @@ contract TestModuleManager_EnableMode is Test, TestModuleManagement_Base {
             mstore(0x3a, 0)
         }
 
-        bytes memory enableModeSig = signMessage(EVE, eip712digest); //should be signed by current owner
+        bytes memory enableModeSig = signPureHash(EVE, eip712digest); //should be signed by current owner
         enableModeSig = abi.encodePacked(address(VALIDATOR_MODULE), enableModeSig); //append validator address
         bytes memory enableModeSigPrefix = abi.encodePacked(
             moduleToEnable,
@@ -288,9 +288,9 @@ contract TestModuleManager_EnableMode is Test, TestModuleManagement_Base {
         PackedUserOperation memory op = makeDraftOp(opValidator);
 
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(op);
-        op.signature = signMessage(ALICE, userOpHash);  // SIGN THE USEROP WITH SIGNER THAT IS ABOUT TO BE USED
+        op.signature = signPureHash(ALICE, userOpHash);  // SIGN THE USEROP WITH SIGNER THAT IS ABOUT TO BE USED
         (bytes memory multiInstallData, bytes32 hashToSign, ) = makeInstallDataAndHash(address(BOB_ACCOUNT), MODULE_TYPE_MULTI, userOpHash);
-        bytes memory enableModeSig = signMessage(BOB, hashToSign); //should be signed by current owner
+        bytes memory enableModeSig = signPureHash(BOB, hashToSign); //should be signed by current owner
         address invalidValidator = address(0xdeaf);
         enableModeSig = abi.encodePacked(invalidValidator, enableModeSig);
 
@@ -325,10 +325,10 @@ contract TestModuleManager_EnableMode is Test, TestModuleManagement_Base {
         PackedUserOperation memory op = makeDraftOp(opValidator);
 
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(op);
-        op.signature = signMessage(ALICE, userOpHash); 
+        op.signature = signPureHash(ALICE, userOpHash); 
         (bytes memory multiInstallData, bytes32 hashToSign, ) = makeInstallDataAndHash(address(BOB_ACCOUNT), MODULE_TYPE_MULTI, userOpHash);
         
-        bytes memory enableModeSig = signMessage(CHARLIE, hashToSign); // SIGN WITH NOT OWNER
+        bytes memory enableModeSig = signPureHash(CHARLIE, hashToSign); // SIGN WITH NOT OWNER
         enableModeSig = abi.encodePacked(address(VALIDATOR_MODULE), enableModeSig);
 
         bytes memory enableModeSigPrefix = abi.encodePacked(
@@ -370,11 +370,11 @@ contract TestModuleManager_EnableMode is Test, TestModuleManagement_Base {
         PackedUserOperation memory op = makeDraftOp(moduleToEnable);
 
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(op);
-        op.signature = signMessage(ALICE, userOpHash); 
+        op.signature = signPureHash(ALICE, userOpHash); 
 
         (bytes memory multiInstallData, bytes32 hashToSign, ) = makeInstallDataAndHash(address(BOB_ACCOUNT), MODULE_TYPE_MULTI, userOpHash);
 
-        bytes memory enableModeSig = signMessage(BOB, hashToSign); 
+        bytes memory enableModeSig = signPureHash(BOB, hashToSign); 
         enableModeSig = abi.encodePacked(address(VALIDATOR_MODULE), enableModeSig);
 
         bytes memory enableModeSigPrefix = abi.encodePacked(
@@ -412,11 +412,11 @@ contract TestModuleManager_EnableMode is Test, TestModuleManagement_Base {
         PackedUserOperation memory op = makeDraftOp(moduleToEnable);
 
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(op);
-        op.signature = signMessage(ALICE, userOpHash); 
+        op.signature = signPureHash(ALICE, userOpHash); 
 
         (bytes memory multiInstallData, bytes32 hashToSign, ) = makeInstallDataAndHash(address(BOB_ACCOUNT), MODULE_TYPE_EXECUTOR, userOpHash);  // Use EXECUTOR type instead of MULTI
 
-        bytes memory enableModeSig = signMessage(BOB, hashToSign); 
+        bytes memory enableModeSig = signPureHash(BOB, hashToSign); 
         enableModeSig = abi.encodePacked(address(VALIDATOR_MODULE), enableModeSig);
 
         bytes memory enableModeSigPrefix = abi.encodePacked(

--- a/test/foundry/unit/concrete/modules/TestK1Validator.t.sol
+++ b/test/foundry/unit/concrete/modules/TestK1Validator.t.sol
@@ -50,7 +50,7 @@ contract TestK1Validator is NexusTest_Base {
         userOpHash = ENTRYPOINT.getUserOpHash(userOp);
 
         // Generate a signature for the user operation hash
-        signature = signMessage(BOB, userOpHash);
+        signature = signPureHash(BOB, userOpHash);
     }
 
     /// @notice Ensures the setUp function works as expected
@@ -111,7 +111,7 @@ contract TestK1Validator is NexusTest_Base {
 
     /// @notice Tests the validateUserOp function with an invalid signature
     function test_ValidateUserOp_Failure() public {
-        userOp.signature = abi.encodePacked(signMessage(BOB, keccak256(abi.encodePacked("invalid"))));
+        userOp.signature = abi.encodePacked(signPureHash(BOB, keccak256(abi.encodePacked("invalid"))));
 
         uint256 validationResult = validator.validateUserOp(userOp, userOpHash);
 

--- a/test/foundry/unit/fuzz/TestFuzz_ValidateUserOp.t.sol
+++ b/test/foundry/unit/fuzz/TestFuzz_ValidateUserOp.t.sol
@@ -23,7 +23,7 @@ contract TestFuzz_ValidateUserOp is NexusTest_Base {
         userOps[0] = buildUserOpWithCalldata(BOB, "", address(VALIDATOR_MODULE));
 
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
-        userOps[0].signature = signMessage(BOB, userOpHash); // Using a valid signature
+        userOps[0].signature = signPureHash(BOB, userOpHash); // Using a valid signature
 
         // Attempt to validate the user operation
         startPrank(address(ENTRYPOINT));
@@ -66,7 +66,7 @@ contract TestFuzz_ValidateUserOp is NexusTest_Base {
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = buildPackedUserOp(BOB.addr, randomNonce);
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
-        userOps[0].signature = signMessage(BOB, userOpHash); // Using a valid signature
+        userOps[0].signature = signPureHash(BOB, userOpHash); // Using a valid signature
 
         prank(BOB.addr);
         prefundSmartAccountAndAssertSuccess(address(BOB_ACCOUNT), missingAccountFunds + 0.1 ether);
@@ -124,7 +124,7 @@ contract TestFuzz_ValidateUserOp is NexusTest_Base {
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = buildPackedUserOp(userAddress, randomNonce);
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
-        userOps[0].signature = signMessage(BOB, userOpHash); // Using a valid signature
+        userOps[0].signature = signPureHash(BOB, userOpHash); // Using a valid signature
 
         address validator;
         assembly {

--- a/test/foundry/utils/TestHelper.t.sol
+++ b/test/foundry/utils/TestHelper.t.sol
@@ -288,7 +288,7 @@ contract TestHelper is CheatCodes, EventsAndErrors {
     /// @return The signed user operation
     function signUserOp(Vm.Wallet memory wallet, PackedUserOperation memory userOp) internal view returns (bytes memory) {
         bytes32 opHash = ENTRYPOINT.getUserOpHash(userOp);
-        return signMessage(wallet, opHash);
+        return signPureHash(wallet, opHash);
     }
 
     // -----------------------------------------
@@ -327,6 +327,11 @@ contract TestHelper is CheatCodes, EventsAndErrors {
     function signMessage(Vm.Wallet memory wallet, bytes32 messageHash) internal pure returns (bytes memory signature) {
         messageHash = ECDSA.toEthSignedMessageHash(messageHash);
 
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(wallet.privateKey, messageHash);
+        signature = abi.encodePacked(r, s, v);
+    }
+
+    function signPureHash(Vm.Wallet memory wallet, bytes32 messageHash) internal pure returns (bytes memory signature) {
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(wallet.privateKey, messageHash);
         signature = abi.encodePacked(r, s, v);
     }
@@ -410,7 +415,7 @@ contract TestHelper is CheatCodes, EventsAndErrors {
 
         // Sign the operation
         bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
-        userOps[0].signature = signMessage(signer, userOpHash);
+        userOps[0].signature = signPureHash(signer, userOpHash);
 
         return userOps;
     }


### PR DESCRIPTION
- make .toEthSignedMessageHash flow => fallback not primary in verifying userOp sigs see **[here](https://github.com/eth-infinitism/account-abstraction/commit/7cbc19bf35691e2f6655868e5d4871ccc80d6e1f#diff-817b4cf911e7a23e51babb2588812f4edd636a607d25792451a70e512840671cR109)**
- sign raw EP.getUserOpHash() in foumdry tests

TODO:

- [ ]  If EP v0.8 is officially released , use it as dependency and change how userOpHash is obtained and signed in Hardhat tests