### PR TITLE
Add Nick's method support on initialization

### DIFF
--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -593,6 +593,7 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
         
         // check auth hash signed by address(this)
         address signer = ECDSA.recover(authHash, signature);
+        // TODO: remove this
         console2.log("signer", signer);
         console2.log("address(this)", address(this));
         assembly {

--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -546,10 +546,17 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
         version = "2.0.0";
     }
 
-    function _authorizeNicksMethod(bytes calldata initData) internal view {
-        // parse auth hash and signature out of initData
+    function _authorizeNicksMethod(bytes calldata data) internal view {
+        assembly {
+            if lt(data.length, 0x61) {
+                mstore(0x0, 0xaed59595) // NotInitializable()
+                revert(0x1c, 0x04)
+            }
+        }
+        // parse auth hash and signature and initData out of data
         // TODO: make calldata parsing here, not abi.decode
-        (bytes32 authHash, bytes memory signature) = abi.decode(initData, (bytes32, bytes));
+        (bytes32 authHash, bytes memory signature) = abi.decode(data, (bytes32, bytes));
+        // TODO: check initData is hashed into initDataHash living in `r` of signature 
         address signer = ECDSA.recover(authHash, signature);
         console2.log("signer", signer);
         console2.log("address(this)", address(this));

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -694,7 +694,13 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
     /// @dev Checks if the account is an ERC7702 account
     ///      by checking the codehash of the account
     ///      and comparing it to the known ERC7702 codehash
+
+    /// TODO: Fix it because it changed in 7702,  
+    /// quote:: EXTCODEHASH would return keccak256(0xef0100 || address)
+    /// benchmark it! 
+
     function _amIERC7702() internal view returns (bool res) {
+        // todo: use extcodesize as the first cheapest check
         assembly {
             res :=
                 eq(

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -534,6 +534,9 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
         address enableModeSigValidator = address(bytes20(sig[0:20]));
         bytes32 eip712Digest = _hashTypedData(structHash);
 
+// TODO: HERE AND IN THE SIMILAR LOGIC (validate userOp, 7821 execution guard) => instead of checking isInitialized to understand if it is 7702,
+// just check sig length. if it is 65 only, then validator is not attached, then it can be 7702 if the sig is valid
+
         if (_isValidatorInstalled(enableModeSigValidator)) {
             // Use standard IERC-1271/ERC-7739 interface.
             // Even if the validator doesn't support 7739 under the hood, it is still secure,
@@ -665,7 +668,7 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
     }
 
     function _eip7702SignatureValidation(bytes32 dataHash, bytes calldata signature, address validator) internal view returns (bool) {
-        if (!_hasValidators() && !_hasExecutors()) {
+        if (!_isAlreadyInitialized()) {
             // Check the userOp signature if the validator is not installed (used for EIP7702)
             return _checkSelfSignature(signature, dataHash);
         } else {

--- a/contracts/interfaces/INexusEventsAndErrors.sol
+++ b/contracts/interfaces/INexusEventsAndErrors.sol
@@ -57,4 +57,7 @@ interface INexusEventsAndErrors {
 
     /// @notice Error thrown when an invalid signature is detected
     error InvalidSignature();
+
+    /// @notice Error thrown when an invalid nicks method data is detected
+    error InvalidNicksMethodData(bytes32 authHash, bytes32 initDataHash, bytes signature);
 }

--- a/contracts/interfaces/base/IStorage.sol
+++ b/contracts/interfaces/base/IStorage.sol
@@ -13,6 +13,7 @@ pragma solidity ^0.8.27;
 // Learn more at https://biconomy.io. To report security issues, please contact us at: security@biconomy.io
 
 import { SentinelListLib } from "sentinellist/SentinelList.sol";
+import { NexusSentinelListLib } from "../../lib/NexusSentinelList.sol";
 import { IPreValidationHookERC1271, IPreValidationHookERC4337 } from "../modules/IPreValidationHook.sol";
 import { IHook } from "../modules/IHook.sol";
 import { CallType } from "../../lib/ModeLib.sol";
@@ -34,7 +35,7 @@ interface IStorage {
         ///< List of validators, initialized upon contract deployment.
         SentinelListLib.SentinelList validators;
         ///< List of executors, similarly initialized.
-        SentinelListLib.SentinelList executors;
+        NexusSentinelListLib.SentinelList executors;
         ///< Mapping of selectors to their respective fallback handlers.
         mapping(bytes4 => FallbackHandler) fallbacks;
         ///< Current hook module associated with this account.

--- a/contracts/lib/Initializable.sol
+++ b/contracts/lib/Initializable.sol
@@ -19,16 +19,13 @@ library Initializable {
         }
     }
 
-    /// @dev Checks if the initializable flag is set in the transient storage slot, reverts with NotInitializable if not
-    function requireInitializable() internal view {
+    /// @dev returns true if the initializable flag is set in the transient storage slot,
+    ///      otherwise returns false
+    function isInitializable() internal view returns (bool isInitializable) {
         bytes32 slot = INIT_SLOT;
-        // Load the current value from the slot, revert if 0
+        // Load the current value from the slot
         assembly {
-            let isInitializable := tload(slot)
-            if iszero(isInitializable) {
-                mstore(0x0, 0xaed59595) // NotInitializable()
-                revert(0x1c, 0x04)
-            }
+            isInitializable := tload(slot)
         }
     }
 }

--- a/contracts/lib/NexusSentinelList.sol
+++ b/contracts/lib/NexusSentinelList.sol
@@ -25,10 +25,10 @@ library NexusSentinelListLib {
         mapping(address => address) entries;
     }
 
-    error LinkedList_AlreadyInitialized();
-    error LinkedList_InvalidPage();
-    error LinkedList_InvalidEntry(address entry);
-    error LinkedList_EntryAlreadyInList(address entry);
+    error NexusSentinelList_AlreadyInitialized();
+    error NexusSentinelList_InvalidPage();
+    error NexusSentinelList_InvalidEntry(address entry);
+    error NexusSentinelList_EntryAlreadyInList(address entry);
 
     /**
      * Initialize the linked list
@@ -36,7 +36,7 @@ library NexusSentinelListLib {
      * @param self The linked list
      */
     function init(SentinelList storage self) internal {
-        if (alreadyInitialized(self)) revert LinkedList_AlreadyInitialized();
+        if (alreadyInitialized(self)) revert NexusSentinelList_AlreadyInitialized();
         if (_isNicksMethodInit()) {
             _writeToMapping(self, SENTINEL, NICKS_SENTINEL);
         } else {
@@ -65,7 +65,7 @@ library NexusSentinelListLib {
      */
     function getNext(SentinelList storage self, address entry) internal view returns (address) {
         if (entry == ZERO_ADDRESS) {
-            revert LinkedList_InvalidEntry(entry);
+            revert NexusSentinelList_InvalidEntry(entry);
         }
         return self.entries[entry];
     }
@@ -78,9 +78,9 @@ library NexusSentinelListLib {
      */
     function push(SentinelList storage self, address newEntry) internal {
         if (newEntry == ZERO_ADDRESS || newEntry == SENTINEL) {
-            revert LinkedList_InvalidEntry(newEntry);
+            revert NexusSentinelList_InvalidEntry(newEntry);
         }
-        if (self.entries[newEntry] != ZERO_ADDRESS) revert LinkedList_EntryAlreadyInList(newEntry);
+        if (self.entries[newEntry] != ZERO_ADDRESS) revert NexusSentinelList_EntryAlreadyInList(newEntry);
         // use assembly to get self.entries[SENTINEL] as bytes32
         bytes32 sentinelValue = _readFromMapping(self, SENTINEL);
         self.entries[newEntry] = self.entries[SENTINEL];
@@ -115,9 +115,9 @@ library NexusSentinelListLib {
      */
     function pop(SentinelList storage self, address prevEntry, address popEntry) internal {
         if (popEntry == ZERO_ADDRESS || popEntry == SENTINEL) {
-            revert LinkedList_InvalidEntry(prevEntry);
+            revert NexusSentinelList_InvalidEntry(prevEntry);
         }
-        if (self.entries[prevEntry] != popEntry) revert LinkedList_InvalidEntry(popEntry);
+        if (self.entries[prevEntry] != popEntry) revert NexusSentinelList_InvalidEntry(popEntry);
         // if prevEntry is the sentinel and there is a nicks method flag at msb
         // use assembly to append it to the self.entries[popEntry]
         if (prevEntry == SENTINEL && _isNicksMSB(_readFromMapping(self, SENTINEL))) {
@@ -185,8 +185,8 @@ library NexusSentinelListLib {
         view
         returns (address[] memory array, address next)
     {
-        if (start != SENTINEL && !contains(self, start)) revert LinkedList_InvalidEntry(start);
-        if (pageSize == 0) revert LinkedList_InvalidPage();
+        if (start != SENTINEL && !contains(self, start)) revert NexusSentinelList_InvalidEntry(start);
+        if (pageSize == 0) revert NexusSentinelList_InvalidPage();
         // Init array with max page size
         array = new address[](pageSize);
 

--- a/contracts/lib/NexusSentinelList.sol
+++ b/contracts/lib/NexusSentinelList.sol
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// Sentinel address
+address constant SENTINEL = address(0x1);
+// Zero address
+address constant ZERO_ADDRESS = address(0x0);
+
+// Nick's method flag storage slot
+// keccak256(abi.encode(uint256(keccak256("nick.method.flag.Nexus")) - 1)) & ~bytes32(uint256(0xff));
+bytes32 constant NICK_METHOD_FLAG_STORAGE_SLOT = 0x3fa30d51722ce05d6eb76e47d8dd946b070ad3c25ac37b9f70694605b18ab200;
+
+/**
+ * @title Fork of the Rhinestone/SentinelListLib
+ * @dev Library for managing a linked list of addresses
+ * @dev Has a flag for Nick's method Nexuses
+ * @dev TODO: Uses custom hashing functions to divide b/w executors and validators
+ */
+library NexusSentinelListLib {
+    // Struct to hold the linked list
+    struct SentinelList {
+        // TODO: make it bytes32 => bytes32 instead of address => address
+        mapping(address => address) entries;
+    }
+
+    error LinkedList_AlreadyInitialized();
+    error LinkedList_InvalidPage();
+    error LinkedList_InvalidEntry(address entry);
+    error LinkedList_EntryAlreadyInList(address entry);
+
+    /**
+     * Initialize the linked list
+     *
+     * @param self The linked list
+     */
+    function init(SentinelList storage self) internal {
+        if (alreadyInitialized(self)) revert LinkedList_AlreadyInitialized();
+        if (_isNickMethodNexus()) {
+            assembly {
+                // compose sentinel with 01 in the msb
+                // 0x0100000000000000000000000000000000000000000000000000000000000001
+            }
+        }
+        self.entries[SENTINEL] = SENTINEL;
+    }
+
+    /**
+     * Check if the linked list is already initialized
+     *
+     * @param self The linked list
+     *
+     * @return bool True if the linked list is already initialized
+     */
+    function alreadyInitialized(SentinelList storage self) internal view returns (bool) {
+        return self.entries[SENTINEL] != ZERO_ADDRESS;
+    }
+
+    /**
+     * Get the next entry in the linked list
+     *
+     * @param self The linked list
+     * @param entry The current entry
+     *
+     * @return address The next entry
+     */
+    function getNext(SentinelList storage self, address entry) internal view returns (address) {
+        if (entry == ZERO_ADDRESS) {
+            revert LinkedList_InvalidEntry(entry);
+        }
+        return self.entries[entry];
+    }
+
+    /**
+     * Push a new entry to the linked list
+     *
+     * @param self The linked list
+     * @param newEntry The new entry
+     */
+    function push(SentinelList storage self, address newEntry) internal {
+        if (newEntry == ZERO_ADDRESS || newEntry == SENTINEL) {
+            revert LinkedList_InvalidEntry(newEntry);
+        }
+        if (self.entries[newEntry] != ZERO_ADDRESS) revert LinkedList_EntryAlreadyInList(newEntry);
+        self.entries[newEntry] = self.entries[SENTINEL];
+        self.entries[SENTINEL] = newEntry;
+    }
+
+    /**
+     * Safe push a new entry to the linked list
+     * @dev This ensures that the linked list is initialized and initializes it if it is not
+     *
+     * @param self The linked list
+     * @param newEntry The new entry
+     */
+    function safePush(SentinelList storage self, address newEntry) internal {
+        if (!alreadyInitialized({ self: self })) {
+            init({ self: self });
+        }
+        push({ self: self, newEntry: newEntry });
+    }
+
+    /**
+     * Pop an entry from the linked list
+     *
+     * @param self The linked list
+     * @param prevEntry The entry before the entry to pop
+     * @param popEntry The entry to pop
+     */
+    function pop(SentinelList storage self, address prevEntry, address popEntry) internal {
+        if (popEntry == ZERO_ADDRESS || popEntry == SENTINEL) {
+            revert LinkedList_InvalidEntry(prevEntry);
+        }
+        if (self.entries[prevEntry] != popEntry) revert LinkedList_InvalidEntry(popEntry);
+        self.entries[prevEntry] = self.entries[popEntry];
+        self.entries[popEntry] = ZERO_ADDRESS;
+    }
+
+    /**
+     * Pop all entries from the linked list
+     *
+     * @param self The linked list
+     */
+    function popAll(SentinelList storage self) internal {
+        address next = self.entries[SENTINEL];
+        while (next != ZERO_ADDRESS) {
+            address current = next;
+            next = self.entries[next];
+            self.entries[current] = ZERO_ADDRESS;
+        }
+    }
+
+    /**
+     * Check if the linked list contains an entry
+     *
+     * @param self The linked list
+     * @param entry The entry to check
+     *
+     * @return bool True if the linked list contains the entry
+     */
+    function contains(SentinelList storage self, address entry) internal view returns (bool) {
+        return SENTINEL != entry && self.entries[entry] != ZERO_ADDRESS;
+    }
+
+    /**
+     * Get all entries in the linked list
+     *
+     * @param self The linked list
+     * @param start The start entry
+     * @param pageSize The page size
+     *
+     * @return array All entries in the linked list
+     * @return next The next entry
+     */
+    function getEntriesPaginated(
+        SentinelList storage self,
+        address start,
+        uint256 pageSize
+    )
+        internal
+        view
+        returns (address[] memory array, address next)
+    {
+        if (start != SENTINEL && !contains(self, start)) revert LinkedList_InvalidEntry(start);
+        if (pageSize == 0) revert LinkedList_InvalidPage();
+        // Init array with max page size
+        array = new address[](pageSize);
+
+        // Populate return array
+        uint256 entryCount = 0;
+        next = self.entries[start];
+        while (next != ZERO_ADDRESS && next != SENTINEL && entryCount < pageSize) {
+            array[entryCount] = next;
+            next = self.entries[next];
+            entryCount++;
+        }
+
+        /**
+         * Because of the argument validation, we can assume that the loop will always iterate over
+         * the valid entry list values
+         *       and the `next` variable will either be an enabled entry or a sentinel address
+         * (signalling the end).
+         *
+         *       If we haven't reached the end inside the loop, we need to set the next pointer to
+         * the last element of the entry array
+         *       because the `next` variable (which is a entry by itself) acting as a pointer to the
+         * start of the next page is neither
+         *       incSENTINELrent page, nor will it be included in the next one if you pass it as a
+         * start.
+         */
+        if (next != SENTINEL && entryCount > 0) {
+            next = array[entryCount - 1];
+        }
+        // Set correct size of returned array
+        // solhint-disable-next-line no-inline-assembly
+        /// @solidity memory-safe-assembly
+        assembly {
+            mstore(array, entryCount)
+        }
+    }
+
+    function _isNickMethodNexus() internal view returns (bool) {
+        bool flag;
+        assembly {
+            flag := tload(NICK_METHOD_FLAG_STORAGE_SLOT)
+        }
+        // return early if flag is true in transient storage so
+        // no extra sload is done
+        if (flag) return true;
+        // check if flag is true in persistent storage
+        assembly {
+            flag := sload(NICK_METHOD_FLAG_STORAGE_SLOT)
+        }
+        return flag;
+    }
+}

--- a/contracts/mocks/ExposedNexus.sol
+++ b/contracts/mocks/ExposedNexus.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import { Nexus } from "contracts/Nexus.sol";
+import { INexus } from "contracts/interfaces/INexus.sol";
+interface IExposedNexus is INexus {
+    function amIERC7702() external view returns (bool);
+}
+
+contract ExposedNexus is Nexus, IExposedNexus {
+
+    constructor(address anEntryPoint) Nexus(anEntryPoint) {}
+
+    function amIERC7702() external view returns (bool) {
+        return _amIERC7702();
+    }
+}
+
+

--- a/test/foundry/unit/concrete/eip7702/TestEIP7702.t.sol
+++ b/test/foundry/unit/concrete/eip7702/TestEIP7702.t.sol
@@ -308,7 +308,7 @@ contract TestEIP7702 is NexusTest_Base {
         
         (bool res, bool res2) = _isERC7702(eip7702account);
         assertTrue(res);
-        assertTrue(res2);
+        assertTrue(res2);    
     }
 
     // HELPER FUNCTION UNTIL FULL 7702 SUPPORT IN TESTS
@@ -334,7 +334,7 @@ contract TestEIP7702 is NexusTest_Base {
             }
             // if it is not 23, we do not even check the code
         }
-        bool res2 = bytes3(code) == bytes3(0x111111);
+        res2 = bytes3(code) == bytes3(0x111111);
         //console2.log("codeSize", codeSize);
         //console2.logBytes32(code);
         return (res, res2);

--- a/test/foundry/unit/concrete/factory/TestAccountFactory_Deployments.t.sol
+++ b/test/foundry/unit/concrete/factory/TestAccountFactory_Deployments.t.sol
@@ -103,7 +103,7 @@ contract TestAccountFactory_Deployments is NexusTest_Base {
         address payable firstAccountAddress = FACTORY.createAccount(_initData, salt);
 
         vm.prank(user.addr); // Even owner cannot reinitialize the account
-        vm.expectRevert(LinkedList_AlreadyInitialized.selector);
+        vm.expectRevert(NexusSentinelList_AlreadyInitialized.selector);
         INexus(firstAccountAddress).initializeAccount(factoryData);
     }
 

--- a/test/foundry/unit/concrete/factory/TestNexusAccountFactory_Deployments.t.sol
+++ b/test/foundry/unit/concrete/factory/TestNexusAccountFactory_Deployments.t.sol
@@ -113,7 +113,7 @@ contract TestNexusAccountFactory_Deployments is NexusTest_Base {
         address payable firstAccountAddress = FACTORY.createAccount(_initData, salt);
 
         vm.prank(user.addr); // Even owner cannot reinitialize the account
-        vm.expectRevert(LinkedList_AlreadyInitialized.selector);
+        vm.expectRevert(NexusSentinelList_AlreadyInitialized.selector);
         INexus(firstAccountAddress).initializeAccount(factoryData);
     }
 

--- a/test/foundry/unit/concrete/nexus-sentinel-list/NexusSentinelListLib_Test.t.sol
+++ b/test/foundry/unit/concrete/nexus-sentinel-list/NexusSentinelListLib_Test.t.sol
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.27;
+
+import { Test } from "forge-std/Test.sol";
+import "forge-std/console2.sol";
+import { NexusSentinelListLib, SENTINEL, ZERO_ADDRESS, NICKS_SENTINEL, NICK_METHOD_FLAG_STORAGE_SLOT } from "contracts/lib/NexusSentinelList.sol";
+
+contract NexusSentinelListLibTest is Test {
+
+    using NexusSentinelListLib for NexusSentinelListLib.SentinelList;
+    
+    struct TestStorage {    
+        NexusSentinelListLib.SentinelList nicksSentinelList;
+        NexusSentinelListLib.SentinelList regularSentinelList;
+    }
+
+    bytes32 internal constant _STORAGE_LOCATION = 0x0bb70095b32b9671358306b0339b4c06e7cbd8cb82505941fba30d1eb5b82f00;
+
+    function _getAccountStorage() internal pure returns (TestStorage storage $) {
+        assembly {
+            $.slot := _STORAGE_LOCATION
+        }
+    }
+    
+    function setUp() public {
+        assembly {
+            sstore(NICK_METHOD_FLAG_STORAGE_SLOT, 0x01)
+        }
+        assertTrue(NexusSentinelListLib._isNicksMethodInit());
+        _getAccountStorage().nicksSentinelList.init();
+        assembly {
+            sstore(NICK_METHOD_FLAG_STORAGE_SLOT, 0x00)
+        }
+        assertFalse(NexusSentinelListLib._isNicksMethodInit());
+        _getAccountStorage().regularSentinelList.init();
+        
+    }
+
+    function test_init() public {
+        TestStorage storage $ = _getAccountStorage();
+        assertTrue($.nicksSentinelList.alreadyInitialized());
+        assertTrue(NexusSentinelListLib._isNicksMethodNexus($.nicksSentinelList));
+        assertTrue($.regularSentinelList.alreadyInitialized());
+        assertFalse(NexusSentinelListLib._isNicksMethodNexus($.regularSentinelList));
+    }
+
+    function _assert_push(address newEntry) public {
+        TestStorage storage $ = _getAccountStorage();
+        $.nicksSentinelList.push(newEntry);
+        assertTrue($.nicksSentinelList._isNicksMethodNexus());
+        assertTrue($.nicksSentinelList.contains(newEntry));
+        $.regularSentinelList.push(newEntry);
+        assertFalse($.regularSentinelList._isNicksMethodNexus());
+        assertTrue($.regularSentinelList.contains(newEntry));
+    }
+
+    function test_push() public {
+        address newEntry = address(0xA11cea11CEA11CEA11cEa11CeA11ceA11CEA11Ce);
+        _assert_push(newEntry);
+    }
+
+    function _assert_pop(address prevEntry, address popEntry) public {
+        TestStorage storage $ = _getAccountStorage();
+        // === nicksSentinelList ===
+        $.nicksSentinelList.pop(prevEntry, popEntry);
+        assertTrue($.nicksSentinelList._isNicksMethodNexus());
+        assertFalse($.nicksSentinelList.contains(popEntry));
+        if (prevEntry != SENTINEL) {
+            assertTrue($.nicksSentinelList.contains(prevEntry));
+        }
+        assertTrue($.nicksSentinelList.alreadyInitialized());
+        // === regularSentinelList ===
+        $.regularSentinelList.pop(prevEntry, popEntry);
+        assertFalse($.regularSentinelList._isNicksMethodNexus());
+        assertFalse($.regularSentinelList.contains(popEntry));
+        if (prevEntry != SENTINEL) {
+            assertTrue($.regularSentinelList.contains(prevEntry));
+        }
+        assertTrue($.regularSentinelList.alreadyInitialized());
+    }
+
+    function test_pop() public {
+        address alice = address(0xA11cea11CEA11CEA11cEa11CeA11ceA11CEA11Ce);
+        address bob = address(0xB0B0b0B0B0B0B0b0B0B0B0b0b0b0b0B0b0b0B0B0);
+        _assert_push(alice);
+        _assert_push(bob);
+        
+        _assert_pop(bob, alice); // pop alice
+        _assert_pop(SENTINEL, bob); // pop bob
+    }
+
+    function test_popAll() public {
+        address alice = address(0xA11cea11CEA11CEA11cEa11CeA11ceA11CEA11Ce);
+        address bob = address(0xB0B0b0B0B0B0B0b0B0B0B0b0b0b0b0B0b0b0B0B0);
+        address charlie = address(0xC0C0c0c0C0C0c0c0c0C0c0C0C0C0C0C0C0C0c0c0);
+        address dan = address(0xD0D0d0d0d0D0D0d0D0D0D0D0d0D0d0d0d0d0D0D0);
+        _assert_push(alice);
+        _assert_push(bob);
+        _assert_push(charlie);
+        _assert_push(dan);
+        TestStorage storage $ = _getAccountStorage();
+        $.nicksSentinelList.popAll();
+        assertTrue($.nicksSentinelList._isNicksMethodNexus());
+        assertFalse($.nicksSentinelList.alreadyInitialized()); // popAll de-inits the list
+        assertFalse($.nicksSentinelList.contains(alice));
+        assertFalse($.nicksSentinelList.contains(bob));
+        assertFalse($.nicksSentinelList.contains(charlie));
+        assertFalse($.nicksSentinelList.contains(dan));
+        bool s_flag;
+        assembly {
+            s_flag := sload(NICK_METHOD_FLAG_STORAGE_SLOT)
+        }
+        assertTrue(s_flag); // expect popAll to set the flag to true in storage
+        assembly {
+            sstore(NICK_METHOD_FLAG_STORAGE_SLOT, 0x00)
+        }
+        $.regularSentinelList.popAll();
+        assertFalse($.regularSentinelList._isNicksMethodNexus());
+        assertFalse($.regularSentinelList.alreadyInitialized()); // popAll de-inits the list
+        assertFalse($.regularSentinelList.contains(alice));
+        assertFalse($.regularSentinelList.contains(bob));
+        assertFalse($.regularSentinelList.contains(charlie));
+        assertFalse($.regularSentinelList.contains(dan));
+    }
+        
+
+        
+    
+    
+}

--- a/test/foundry/unit/fuzz/TestFuzz_ModuleManager.t.sol
+++ b/test/foundry/unit/fuzz/TestFuzz_ModuleManager.t.sol
@@ -133,8 +133,12 @@ contract TestFuzz_ModuleManager is TestModuleManagement_Base {
                 address(VALIDATOR_MODULE),
                 0
             );
-            
-            bytes memory expectedRevertReason = abi.encodeWithSignature("LinkedList_EntryAlreadyInList(address)", moduleAddress);
+            bytes memory expectedRevertReason;
+            if (moduleTypeId == MODULE_TYPE_VALIDATOR) {
+                expectedRevertReason = abi.encodeWithSignature("LinkedList_EntryAlreadyInList(address)", moduleAddress);
+            } else if (moduleTypeId == MODULE_TYPE_EXECUTOR) {
+                expectedRevertReason = abi.encodeWithSignature("NexusSentinelList_EntryAlreadyInList(address)", moduleAddress);
+            } 
             if(moduleTypeId == MODULE_TYPE_FALLBACK) {
                 expectedRevertReason = abi.encodeWithSignature("FallbackAlreadyInstalledForSelector(bytes4)", bytes4(funcSig));
             } else if (moduleTypeId == MODULE_TYPE_HOOK) {

--- a/test/foundry/utils/EventsAndErrors.sol
+++ b/test/foundry/utils/EventsAndErrors.sol
@@ -62,6 +62,7 @@ contract EventsAndErrors {
     // ==========================
     error LinkedList_AlreadyInitialized();
     error LinkedList_InvalidPage();
+    error NexusSentinelList_AlreadyInitialized();
 
     // ==========================
     // Module Errors

--- a/test/foundry/utils/Imports.sol
+++ b/test/foundry/utils/Imports.sol
@@ -47,6 +47,7 @@ import "../../../contracts/factory/NexusAccountFactory.sol";
 import "../../../contracts/factory/RegistryFactory.sol";
 import "./../../../contracts/modules/validators/K1Validator.sol";
 import "../../../contracts/common/Stakeable.sol";
+import "../../../contracts/mocks/ExposedNexus.sol";
 
 // ==========================
 // Mock Contracts for Testing


### PR DESCRIPTION
- Check that the 7702 auth hash was signed by address this
- Check that `r` value of the auth signature contains hash of the `initData`
- Check that `s` value of the auth signature matches the pattern (20 MSB are 0s)
- Introduces custom SentinelList library that stores info about is this a Nick's method Nexus or not. It is done to not use a separate SSTORE at initialization, but using some already used slot. 

**! Needs extensive testing, especially for the Nick's method initialization flow**
