### PR TITLE
Clean init flows as per aa 521

### DIFF
--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -365,7 +365,16 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
             }
         } else {
             // try to check the signature against the account
-            if (_checkSelfSignature(signature, hash)) {
+            //if (_checkSelfSignature(signature, hash)) {
+            
+            // This won't be needed.
+            // Because we will basically forward everythng to validator, and if it supports 7739
+            // we will be safe.
+            // If a signature is a pre-issued sig by EOA, and the 1271 request is not coming
+            // from a safe sender, then it will go to 7739 flow and will have to be safe there.
+            // Thus (assuming validator is initialized) we still support safe pre-issued signatures.
+            // See below about potentially unsafe pre-issued sigs. 
+
                 // if it was signed by address(this),
                 // we still revert on this, to protect from the following attack vector:
                 // 1. This 7702 account (being an eoa as well) owns some other Smart Account (Smart Account B)
@@ -374,11 +383,11 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
                 //    over unsafe hash could be replayed here
                 // Thus, we revert here, but we revert with informational message, that
                 // lets know that the sig is ok, it is just potentially unsafe.
-                revert PotentiallyUnsafeSignature();
-            } else {
+                //revert PotentiallyUnsafeSignature();
+            //} else {
                 // othwerwise revert normally
-                revert ValidatorNotInstalled(validator);
-            }
+                //revert ValidatorNotInstalled(validator);
+            //}
         }
     }
 

--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -349,6 +349,11 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
         }
         // else proceed with normal signature verification
         // First 20 bytes of data will be validator address and rest of the bytes is complete signature.
+
+        // TODO: ADD DEFAULT VALIDATOR FLOW
+        // NOTE: Maybe it will be cheaper to use the calldata flag 
+        // instead of doing _isValidatorInstalled() which is SLOAD
+
         address validator = address(bytes20(signature[0:20]));
         if (_isValidatorInstalled(validator)) {
             bytes memory signature_;
@@ -532,6 +537,8 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
                     // it will still be able to use erc-7821 batch call with opData initialization
                     
                     // TODO: USE DEFAULT VALIDATOR INSTEAD => CHECK ModuleManager._checkEnableModeSignature()
+                    // NOTE: Maybe it will be cheaper to use the calldata flag 
+                    // instead of doing _isValidatorInstalled() which is SLOAD
                 }
                 if (res) return (callType, execType, executionData);
             }

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -536,11 +536,13 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
         address enableModeSigValidator = address(bytes20(sig[0:20]));
         bytes32 eip712Digest = _hashTypedData(structHash);
 
+        // NOTE: Maybe it will be cheaper to use the calldata flag 
+        // instead of doing _isValidatorInstalled() which is SLOAD
         if (_isValidatorInstalled(enableModeSigValidator)) {
             sig = sig[20:];
         } else {
             // use default validator
-            // enableModeSigValidator = DEFAULT_VALIDATOR
+            // TODO: enableModeSigValidator = DEFAULT_VALIDATOR
 
             // in this case we expect sig to not contain validator address
 

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -686,7 +686,7 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
             if eq(extcodesize(address()), 23) {
                 // use extcodecopy to copy first 3 bytes of this contract and compare with 0xef0100
                 let ptr := mload(0x40)
-                extcodecopy(address(), ptr, 0, 3)
+                codecopy(ptr, 0, 3)
                 c := mload(ptr)
             }
             // if it is not 23, we do not even check the code


### PR DESCRIPTION
As per AA-521 https://github.com/eth-infinitism/account-abstraction/pull/529/files#diff-e5a17bf464109f401b78513c9f091ed9874b8b0845c19ec7ea470fe5e665aa04

we do not need custom flow for 770-2 accs at first validateUserOp, we can just use userOp.initcode for initdata

- [ ] Test it via ep v 0.8
