### PR TITLE
Test 7702 via proper code etching with Prague hardfork

### DIFF
--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -694,8 +694,6 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
     }
 
     /// @dev Checks if the account is an ERC7702 account
-    ///      by checking the codehash of the account
-    ///      and comparing it to the known ERC7702 codehash
     function _amIERC7702() internal view returns (bool) {
         bytes32 c;
         assembly {
@@ -706,7 +704,7 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
                 extcodecopy(address(), ptr, 0, 3)
                 c := mload(ptr)
             }
-            // if it is not 23, we do not even check the code
+            // if it is not 23, we do not even check the first 3 bytes
         }
         return bytes3(c) == bytes3(0xef0100);
     }

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,7 +4,7 @@
   auto_detect_solc = false
   block_timestamp = 1_680_220_800 # March 31, 2023 at 00:00 GMT
   bytecode_hash = "none"
-  evm_version = "cancun"           # See https://www.evmdiff.com/features?name=PUSH0&kind=opcode
+  evm_version = "prague"           # See https://www.evmdiff.com/features?name=PUSH0&kind=opcode
   fuzz = { runs = 1_000 }
   via-ir = false
   gas_reports = ["*"]

--- a/test/foundry/unit/concrete/eip7702/TestEIP7702.t.sol
+++ b/test/foundry/unit/concrete/eip7702/TestEIP7702.t.sol
@@ -26,7 +26,8 @@ contract TestEIP7702 is NexusTest_Base {
     }
 
     function _doEIP7702(address account) internal {
-        vm.etch(account, address(ACCOUNT_IMPLEMENTATION).code);
+        //vm.etch(account, address(ACCOUNT_IMPLEMENTATION).code);
+        vm.etch(account, abi.encodePacked(bytes3(0xef0100), bytes20(address(ACCOUNT_IMPLEMENTATION))));
     }
 
     function _getInitData() internal view returns (bytes memory) {

--- a/test/foundry/unit/concrete/eip7702/TestEIP7702.t.sol
+++ b/test/foundry/unit/concrete/eip7702/TestEIP7702.t.sol
@@ -26,7 +26,6 @@ contract TestEIP7702 is NexusTest_Base {
     }
 
     function _doEIP7702(address account) internal {
-        //vm.etch(account, address(ACCOUNT_IMPLEMENTATION).code);
         vm.etch(account, abi.encodePacked(bytes3(0xef0100), bytes20(address(ACCOUNT_IMPLEMENTATION))));
     }
 
@@ -295,49 +294,10 @@ contract TestEIP7702 is NexusTest_Base {
         assertTrue(INexus(account).isModuleInstalled(MODULE_TYPE_PREVALIDATION_HOOK_ERC4337, address(preValidationHook), ""));
     }
 
-    // TODO:  make proper tests when Foundry supports 7702 and etching of 0xef0100xxxx
     function test_amIERC7702_success()public {
         ExposedNexus exposedNexus = new ExposedNexus(address(ENTRYPOINT));
         address eip7702account = address(0x7702acc7702acc7702acc7702acc);
-        // vm.etch(eip7702account, abi.encodePacked(bytes3(0xef0100), bytes20(address(exposedNexus))));
-        // assertTrue(IExposedNexus(eip7702account).amIERC7702()); // it doesnt work yet as forge tests can not do proper 7702 atm
-        
-        // can not even etch 0xef0100 as forge considers 00 as end of code and stops etching
-        // using 111111 as a temporary workaround
-        vm.etch(eip7702account, hex'11111196d3f6c20eed2697647f543fe6c08bc2fbf39758');
-        //console2.logBytes(eip7702account.code);
-        
-        (bool res, bool res2) = _isERC7702(eip7702account);
-        assertTrue(res);
-        assertTrue(res2);    
-    }
-
-    // HELPER FUNCTION UNTIL FULL 7702 SUPPORT IN TESTS
-    function _isERC7702(address account) internal view returns (bool res, bool res2) {
-        uint256 codeSize;
-        bytes32 code;
-        assembly {
-            // use extcodesize as the first cheapest check
-            codeSize := extcodesize(account)
-            if eq(codeSize, 23) {
-                // use extcodecopy to copy first 3 bytes of this contract and compare with 0xef0100 // 0x111111
-                let ptr := mload(0x40)
-                extcodecopy(account, ptr, 0, 3)
-                code := and(mload(ptr), 0xffffff0000000000000000000000000000000000000000000000000000000000)
-                //if eq(mload(ptr), 0xef0100) {
-                if eq(
-                        code, 
-                        0x1111110000000000000000000000000000000000000000000000000000000000
-                    ) {
-                        res := true
-                }
-                
-            }
-            // if it is not 23, we do not even check the code
-        }
-        res2 = bytes3(code) == bytes3(0x111111);
-        //console2.log("codeSize", codeSize);
-        //console2.logBytes32(code);
-        return (res, res2);
+        vm.etch(eip7702account, abi.encodePacked(bytes3(0xef0100), bytes20(address(exposedNexus))));
+        assertTrue(IExposedNexus(eip7702account).amIERC7702());
     }
 }

--- a/test/foundry/unit/fuzz/TestFuzz_ExecuteFromExecutor.t.sol
+++ b/test/foundry/unit/fuzz/TestFuzz_ExecuteFromExecutor.t.sol
@@ -45,7 +45,7 @@ contract TestFuzz_ExecuteFromExecutor is NexusTest_Base {
     /// @param target The target address for the execution
     /// @param value The value to be transferred in the execution
     function testFuzz_ExecuteSingleFromExecutor(address target, uint256 value) public {
-        vm.assume(uint160(address(target)) > 10);
+        vm.assume(uint160(address(target)) > 255); // do not hit precompiles
         vm.assume(!isContract(target));
         vm.assume(value < 1_000_000_000 ether);
         vm.deal(address(BOB_ACCOUNT), value);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the configurations and tests related to the `evm_version` and ERC7702 functionality in the smart contract testing framework. It enhances the assumptions in tests and modifies the implementation details for better compatibility with the ERC7702 standard.

### Detailed summary
- Updated `evm_version` in `foundry.toml` from `cancun` to `prague`.
- Changed assumption in `testFuzz_ExecuteSingleFromExecutor` to ensure `target` address is greater than `255`.
- Revised the comment in the `_amIERC7702` function for clarity.
- Updated the `vm.etch` call in `_doEIP7702` to properly encode the `ACCOUNT_IMPLEMENTATION` address.
- Restored the test for `amIERC7702` functionality in `test_amIERC7702_success` to work correctly with the new `vm.etch` implementation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->