### PR TITLE
Release v1.0.2

### DIFF
--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -363,6 +363,6 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
     /// @dev EIP712 domain name and version.
     function _domainNameAndVersion() internal pure override returns (string memory name, string memory version) {
         name = "Nexus";
-        version = "1.0.1";
+        version = "1.0.2";
     }
 }

--- a/contracts/base/BaseAccount.sol
+++ b/contracts/base/BaseAccount.sol
@@ -25,7 +25,7 @@ import { IBaseAccount } from "../interfaces/base/IBaseAccount.sol";
 /// Special thanks to the Solady team for foundational contributions: https://github.com/Vectorized/solady
 contract BaseAccount is IBaseAccount {
     /// @notice Identifier for this implementation on the network
-    string internal constant _ACCOUNT_IMPLEMENTATION_ID = "biconomy.nexus.1.0.0";
+    string internal constant _ACCOUNT_IMPLEMENTATION_ID = "biconomy.nexus.1.0.2";
 
     /// @notice The canonical address for the ERC4337 EntryPoint contract, version 0.7.
     /// This address is consistent across all supported networks.

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -448,16 +448,20 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
                 revert UnsupportedCallType(calltype);
             }
 
+            // Use revert message from fallback handler if the call was not successful
+            assembly {
+                if iszero(success) {
+                    revert(add(result, 0x20), mload(result))
+                }
+            }
+
             // hook post check
             if (hook != address(0)) {
                 IHook(hook).postCheck(hookData);
             }
 
+            // return the result
             assembly {
-                if iszero(success) {
-                    // Use revert message from fallback handler if the call was not successful
-                    revert(add(result, 0x20), mload(result))
-                }
                 return(add(result, 0x20), mload(result))
             }
         }

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -64,8 +64,8 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
     receive() external payable {}
 
     /// @dev Fallback function to manage incoming calls using designated handlers based on the call type.
-    fallback(bytes calldata callData) external payable withHook returns (bytes memory) {
-        return _fallback(callData);
+    fallback() external payable withHook {
+        _fallback(msg.data);
     }
 
     /// @dev Retrieves a paginated list of validator addresses from the linked list.
@@ -424,8 +424,9 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
         hook = address(_getAccountStorage().hook);
     }
 
-    function _fallback(bytes calldata callData) private returns (bytes memory result) {
+    function _fallback(bytes calldata callData) private {
         bool success;
+        bytes memory result;
         FallbackHandler storage $fallbackHandler = _getAccountStorage().fallbacks[msg.sig];
         address handler = $fallbackHandler.handler;
         CallType calltype = $fallbackHandler.calltype;
@@ -441,11 +442,13 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
             }
 
             // Use revert message from fallback handler if the call was not successful
-            if (!success) {
-                assembly {
+            assembly {
+                if iszero(success) {
                     revert(add(result, 0x20), mload(result))
                 }
+                return (add(result, 0x20), mload(result))
             }
+            
         } else {
             // If there's no handler, the call can be one of onERCXXXReceived()
             bytes32 s;
@@ -457,10 +460,8 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
                 // 0xbc197c81: `onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)`.
                 if or(eq(s, 0x150b7a02), or(eq(s, 0xf23a6e61), eq(s, 0xbc197c81))) {
                     success := true // it is one of onERCXXXReceived
-                    result := mload(0x40) //result was set to 0x60 as it was empty, so we need to find a new space for it
-                    mstore(result, 0x04) //store length
-                    mstore(add(result, 0x20), shl(224, s)) //store calldata
-                    mstore(0x40, add(result, 0x24)) //allocate memory
+                    mstore(0x20, s) // Store `msg.sig`.
+                    return(0x3c, 0x20) // Return `msg.sig`.
                 }
             }
             // if there was no handler and it is not the onERCXXXReceived call, revert

--- a/contracts/mocks/MockHandler.sol
+++ b/contracts/mocks/MockHandler.sol
@@ -6,8 +6,8 @@ import { MODULE_TYPE_FALLBACK } from "..//types/Constants.sol";
 
 contract MockHandler is IFallback {
     uint256 public count;
-    string public constant NAME = "Default Handler";
-    string public constant VERSION = "1.0.0";
+    string constant NAME = "Default Handler";
+    string constant VERSION = "1.0.0";
 
     event GenericFallbackCalled(address sender, uint256 value, bytes data); // Event for generic fallback
     event HandlerOnInstallCalled(bytes32 dataFirstWord);
@@ -22,6 +22,16 @@ contract MockHandler is IFallback {
     function onGenericFallback(address sender, uint256 value, bytes calldata data) external returns (bytes4) {
         emit GenericFallbackCalled(sender, value, data);
         return this.onGenericFallback.selector;
+    }
+
+    function complexReturnData(string memory input, bytes4 selector) external view returns (uint256, bytes memory, address, uint64, address) {
+        return (
+            uint256(block.timestamp),
+            abi.encode(input, NAME, VERSION, selector),
+            address(this),
+            uint64(block.chainid),
+            _msgSender()
+        );
     }
 
     function onInstall(bytes calldata data) external override {
@@ -54,5 +64,23 @@ contract MockHandler is IFallback {
 
     function getState() external view returns (uint256) {
         return count;
+    }
+
+    function getName() external pure returns (string memory) {
+        return NAME;
+    }
+
+    function getVersion() external pure returns (string memory) {
+        return VERSION;
+    }
+
+    function _msgSender() internal pure returns (address sender) {
+        // The assembly code is more direct than the Solidity version using `abi.decode`.
+        /* solhint-disable no-inline-assembly */
+        /// @solidity memory-safe-assembly
+        assembly {
+            sender := shr(96, calldataload(sub(calldatasize(), 20)))
+        }
+        /* solhint-enable no-inline-assembly */
     }
 }

--- a/contracts/mocks/MockHandler.sol
+++ b/contracts/mocks/MockHandler.sol
@@ -34,6 +34,10 @@ contract MockHandler is IFallback {
         );
     }
 
+    function returnBytes() external view returns (bytes memory) {
+        return abi.encodePacked(NAME, VERSION);
+    }
+
     function onInstall(bytes calldata data) external override {
         if (data.length >= 0x20) {
             emit HandlerOnInstallCalled(bytes32(data[0:32]));

--- a/contracts/mocks/MockNFT.sol
+++ b/contracts/mocks/MockNFT.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.27;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
 
 contract MockNFT is ERC721 {
     constructor(string memory name, string memory symbol) ERC721(name, symbol) {}
@@ -16,5 +17,21 @@ contract MockNFT is ERC721 {
     // Warning: This function is only for testing purposes and should not be used in production
     function safeMint(address to, uint256 tokenId) public {
         _safeMint(to, tokenId);
+    }
+
+    function safeTransfer(address to, uint256 tokenId) public {
+        _safeTransfer(msg.sender, to, tokenId);
+    }
+}
+
+contract MockERC1155 is ERC1155 {
+    constructor(string memory uri) ERC1155(uri) {}
+
+    function safeMint(address to, uint256 tokenId, uint256 amount) public {
+        _mint(to, tokenId, amount, "");
+    }
+
+    function safeMintBatch(address to, uint256[] memory tokenIds, uint256[] memory amounts) public {
+        _mintBatch(to, tokenIds, amounts, "");
     }
 }

--- a/contracts/modules/validators/K1Validator.sol
+++ b/contracts/modules/validators/K1Validator.sol
@@ -76,6 +76,7 @@ contract K1Validator is IValidator, ERC7739Validator {
         require(!_isInitialized(msg.sender), ModuleAlreadyInitialized());
         address newOwner = address(bytes20(data[:20]));
         require(newOwner != address(0), OwnerCannotBeZeroAddress());
+        require(!_isContract(newOwner), NewOwnerIsContract());
         smartAccountOwners[msg.sender] = newOwner;
         if (data.length > 20) {
             _fillSafeSenders(data[20:]);

--- a/contracts/modules/validators/K1Validator.sol
+++ b/contracts/modules/validators/K1Validator.sol
@@ -191,7 +191,7 @@ contract K1Validator is IValidator, ERC7739Validator {
     /// @notice Returns the version of the module
     /// @return The version of the module
     function version() external pure returns (string memory) {
-        return "1.0.1";
+        return "1.0.2";
     }
 
     /// @notice Checks if the module is of the specified type

--- a/contracts/modules/validators/K1Validator.sol
+++ b/contracts/modules/validators/K1Validator.sol
@@ -76,7 +76,6 @@ contract K1Validator is IValidator, ERC7739Validator {
         require(!_isInitialized(msg.sender), ModuleAlreadyInitialized());
         address newOwner = address(bytes20(data[:20]));
         require(newOwner != address(0), OwnerCannotBeZeroAddress());
-        require(!_isContract(newOwner), NewOwnerIsContract());
         smartAccountOwners[msg.sender] = newOwner;
         if (data.length > 20) {
             _fillSafeSenders(data[20:]);

--- a/test/foundry/fork/arbitrum/ArbitrumSmartAccountUpgradeTest.t.sol
+++ b/test/foundry/fork/arbitrum/ArbitrumSmartAccountUpgradeTest.t.sol
@@ -45,7 +45,7 @@ contract ArbitrumSmartAccountUpgradeTest is NexusTest_Base, ArbitrumSettings {
     /// @notice Validates the account ID after the upgrade process.
     function test_AccountIdValidationAfterUpgrade() public {
         test_UpgradeV2ToV3AndInitialize();
-        string memory expectedAccountId = "biconomy.nexus.1.0.0";
+        string memory expectedAccountId = "biconomy.nexus.1.0.2";
         string memory actualAccountId = IAccountConfig(payable(address(smartAccountV2))).accountId();
         assertEq(actualAccountId, expectedAccountId, "Account ID does not match after upgrade.");
     }

--- a/test/foundry/unit/concrete/accountconfig/TestAccountConfig_AccountId.t.sol
+++ b/test/foundry/unit/concrete/accountconfig/TestAccountConfig_AccountId.t.sol
@@ -19,7 +19,7 @@ contract TestAccountConfig_AccountId is Test {
 
     /// @notice Tests if the account ID returns the expected value
     function test_WhenCheckingTheAccountID() external givenTheAccountConfiguration {
-        string memory expected = "biconomy.nexus.1.0.0";
+        string memory expected = "biconomy.nexus.1.0.2";
         assertEq(accountConfig.accountId(), expected, "AccountConfig should return the expected account ID.");
     }
 }

--- a/test/foundry/unit/concrete/factory/TestAccountFactory_Deployments.t.sol
+++ b/test/foundry/unit/concrete/factory/TestAccountFactory_Deployments.t.sol
@@ -72,7 +72,7 @@ contract TestAccountFactory_Deployments is NexusTest_Base {
         userOps[0] = buildUserOpWithInitAndCalldata(user, initCode, "", address(VALIDATOR_MODULE));
         ENTRYPOINT.depositTo{ value: 1 ether }(address(accountAddress));
         ENTRYPOINT.handleOps(userOps, payable(user.addr));
-        assertEq(IAccountConfig(accountAddress).accountId(), "biconomy.nexus.1.0.0", "Not deployed properly");
+        assertEq(IAccountConfig(accountAddress).accountId(), "biconomy.nexus.1.0.2", "Not deployed properly");
     }
 
     /// @notice Tests that deploying an account fails if it already exists.

--- a/test/foundry/unit/concrete/factory/TestNexusAccountFactory_Deployments.t.sol
+++ b/test/foundry/unit/concrete/factory/TestNexusAccountFactory_Deployments.t.sol
@@ -83,7 +83,7 @@ contract TestNexusAccountFactory_Deployments is NexusTest_Base {
         userOps[0] = buildUserOpWithInitAndCalldata(user, initCode, "", address(VALIDATOR_MODULE));
         ENTRYPOINT.depositTo{ value: 1 ether }(address(accountAddress));
         ENTRYPOINT.handleOps(userOps, payable(user.addr));
-        assertEq(IAccountConfig(accountAddress).accountId(), "biconomy.nexus.1.0.0", "Not deployed properly");
+        assertEq(IAccountConfig(accountAddress).accountId(), "biconomy.nexus.1.0.2", "Not deployed properly");
     }
 
     /// @notice Tests that deploying an account fails if it already exists.

--- a/test/foundry/unit/concrete/gas/TestGas_NexusAccountFactory.t.sol
+++ b/test/foundry/unit/concrete/gas/TestGas_NexusAccountFactory.t.sol
@@ -71,7 +71,7 @@ contract TestGas_NexusAccountFactory is TestModuleManagement_Base {
     /// @notice Validates the creation of a new account.
     /// @param _account The new account address.
     function assertValidCreation(Nexus _account) internal {
-        string memory expected = "biconomy.nexus.1.0.0";
+        string memory expected = "biconomy.nexus.1.0.2";
         assertEq(_account.accountId(), expected, "AccountConfig should return the expected account ID.");
         assertTrue(
             _account.isModuleInstalled(MODULE_TYPE_VALIDATOR, address(VALIDATOR_MODULE), ""), "Account should have the validation module installed"

--- a/test/foundry/unit/concrete/modulemanager/TestModuleManager_FallbackHandler.t.sol
+++ b/test/foundry/unit/concrete/modulemanager/TestModuleManager_FallbackHandler.t.sol
@@ -84,24 +84,12 @@ contract TestModuleManager_FallbackHandler is TestModuleManagement_Base {
         // Prepare UserOperation
         PackedUserOperation[] memory userOps = buildPackedUserOperation(BOB, BOB_ACCOUNT, EXECTYPE_DEFAULT, executions, address(VALIDATOR_MODULE), 0);
 
-        if (!skip) {
-            // Expect the GenericFallbackCalled event from the MockHandler contract
-            vm.expectEmit(true, true, false, true, address(HANDLER_MODULE));
-            emit GenericFallbackCalled(address(this), 123, "Example data");
-        }
+        // Expect the GenericFallbackCalled event from the MockHandler contract
+        vm.expectEmit(true, true, false, true, address(HANDLER_MODULE));
+        emit GenericFallbackCalled(address(this), 123, "Example data");
 
         // Call handleOps, which should trigger the fallback handler and emit the event
         ENTRYPOINT.handleOps(userOps, payable(address(BOB.addr)));
-    }
-
-    /// @notice Tests that handleOps triggers the generic fallback handler.
-    function test_HandleOpsTriggersGenericFallback_IsProperlyHooked() public {
-        vm.expectEmit(address(HOOK_MODULE));
-        emit PreCheckCalled();
-        vm.expectEmit(address(HOOK_MODULE));
-        emit PostCheckCalled();
-        // skip fallback emit check as per Matching Sequences section here => https://book.getfoundry.sh/cheatcodes/expect-emit 
-        test_HandleOpsTriggersGenericFallback({skip: true});
     }
 
     /// @notice Tests installing a fallback handler.
@@ -410,6 +398,10 @@ contract TestModuleManager_FallbackHandler is TestModuleManagement_Base {
         assertTrue(success);
         assertEq(abi.decode(result, (bytes)), expectedResult);
 
+        vm.expectEmit(true, true, true, true, address(HOOK_MODULE));
+        emit PreCheckCalled();
+        vm.expectEmit(true, true, true, true, address(HOOK_MODULE));
+        emit PostCheckCalled();
         bytes memory result2 = IHandler(address(BOB_ACCOUNT)).returnBytes();
         assertEq(result2, expectedResult);
     }

--- a/test/foundry/unit/concrete/modulemanager/TestModuleManager_FallbackHandler.t.sol
+++ b/test/foundry/unit/concrete/modulemanager/TestModuleManager_FallbackHandler.t.sol
@@ -373,7 +373,7 @@ contract TestModuleManager_FallbackHandler is TestModuleManagement_Base {
         assertEq(keccak256(resultData), keccak256(expectedData));
     }
 
-    function test_ReturnBytes() public {
+    function test_ReturnBytes_and_Hook_fallback() public {
         bytes4 selector = bytes4(keccak256(abi.encodePacked("returnBytes()")));
         bytes memory customData = abi.encode(bytes5(abi.encodePacked(selector, CALLTYPE_SINGLE)));
         bytes memory callData = abi.encodeWithSelector(

--- a/test/foundry/unit/concrete/modules/TestK1Validator.t.sol
+++ b/test/foundry/unit/concrete/modules/TestK1Validator.t.sol
@@ -187,7 +187,7 @@ contract TestK1Validator is NexusTest_Base {
     function test_Version() public {
         string memory contractVersion = validator.version();
 
-        assertEq(contractVersion, "1.0.1", "Contract version should be '1.0.1'");
+        assertEq(contractVersion, "1.0.2", "Contract version should be '1.0.2'");
     }
 
     /// @notice Tests the isModuleType function to return the correct module type
@@ -383,7 +383,7 @@ contract TestK1Validator is NexusTest_Base {
             abi.encode(
                 keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
                 keccak256("Nexus"),
-                keccak256("1.0.1"),
+                keccak256("1.0.2"),
                 block.chainid,
                 address(BOB_ACCOUNT)
             )

--- a/test/hardhat/smart-account/Nexus.Basics.specs.ts
+++ b/test/hardhat/smart-account/Nexus.Basics.specs.ts
@@ -133,7 +133,7 @@ describe("Nexus Basic Specs", function () {
 
   describe("Smart Account Basics", function () {
     it("Should correctly return the Nexus's ID", async function () {
-      expect(await smartAccount.accountId()).to.equal("biconomy.nexus.1.0.0");
+      expect(await smartAccount.accountId()).to.equal("biconomy.nexus.1.0.2");
     });
 
     it("Should get implementation address of smart account", async () => {

--- a/test/hardhat/smart-account/Nexus.Module.K1Validator.specs.ts
+++ b/test/hardhat/smart-account/Nexus.Module.K1Validator.specs.ts
@@ -61,7 +61,7 @@ describe("K1Validator module tests", () => {
     });
   });
 
-  describe("K1Validtor tests", () => {
+  describe("K1Validator tests", () => {
     it("should check if validator is installed", async () => {
       expect(
         await deployedNexus.isModuleInstalled(
@@ -79,7 +79,7 @@ describe("K1Validator module tests", () => {
 
     it("should get module version", async () => {
       const version = await k1Validator.version();
-      expect(version).to.equal("1.0.1");
+      expect(version).to.equal("1.0.2");
     });
 
     it("should check module type", async () => {


### PR DESCRIPTION
- [x] Adds hotfix to fallback function
- [x] Adds more detailed testing including complex scenarios

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily updates the versioning of the `Nexus` contract and its associated modules, reflecting a transition from version `1.0.1` to `1.0.2`. It also includes adjustments in tests and mock contracts to ensure consistency with the new version.

### Detailed summary
- Updated `_domainNameAndVersion` in `contracts/Nexus.sol` to version `1.0.2`.
- Changed `version()` function in `K1Validator` to return `1.0.2`.
- Updated expected account IDs in tests to `biconomy.nexus.1.0.2`.
- Modified constant `_ACCOUNT_IMPLEMENTATION_ID` in `BaseAccount` to `1.0.2`.
- Adjusted assertions in multiple test files to verify the new version.
- Fixed typo in test description from `K1Validtor` to `K1Validator`.
- Added new functions in `MockHandler` for complex return data and bytes return.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->