### PR TITLE
Revert k1 validator version

### DIFF
--- a/contracts/modules/validators/K1Validator.sol
+++ b/contracts/modules/validators/K1Validator.sol
@@ -192,7 +192,7 @@ contract K1Validator is IValidator, ERC7739Validator {
     /// @notice Returns the version of the module
     /// @return The version of the module
     function version() external pure returns (string memory) {
-        return "1.0.2";
+        return "1.0.1";
     }
 
     /// @notice Checks if the module is of the specified type

--- a/test/foundry/unit/concrete/modules/TestK1Validator.t.sol
+++ b/test/foundry/unit/concrete/modules/TestK1Validator.t.sol
@@ -187,7 +187,7 @@ contract TestK1Validator is NexusTest_Base {
     function test_Version() public {
         string memory contractVersion = validator.version();
 
-        assertEq(contractVersion, "1.0.2", "Contract version should be '1.0.2'");
+        assertEq(contractVersion, "1.0.1", "Contract version should be '1.0.1'");
     }
 
     /// @notice Tests the isModuleType function to return the correct module type

--- a/test/hardhat/smart-account/Nexus.Module.K1Validator.specs.ts
+++ b/test/hardhat/smart-account/Nexus.Module.K1Validator.specs.ts
@@ -79,7 +79,7 @@ describe("K1Validator module tests", () => {
 
     it("should get module version", async () => {
       const version = await k1Validator.version();
-      expect(version).to.equal("1.0.2");
+      expect(version).to.equal("1.0.1");
     });
 
     it("should check module type", async () => {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the version number of the `K1Validator` module from `1.0.2` to `1.0.1` in multiple places, ensuring consistency across the codebase and tests.

### Detailed summary
- Updated the `version()` function in `contracts/modules/validators/K1Validator.sol` to return `"1.0.1"` instead of `"1.0.2"`.
- Modified the test in `test/hardhat/smart-account/Nexus.Module.K1Validator.specs.ts` to expect the version to be `"1.0.1"`.
- Changed the assertion in `test/foundry/unit/concrete/modules/TestK1Validator.t.sol` to check for the version `"1.0.1"`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->