### PR TITLE
fix(IPreValidationHook): make 4337 hook non-view

### DIFF
--- a/contracts/interfaces/modules/IPreValidationHook.sol
+++ b/contracts/interfaces/modules/IPreValidationHook.sol
@@ -33,6 +33,5 @@ interface IPreValidationHookERC4337 is IModule {
         bytes32 userOpHash
     )
         external
-        view
         returns (bytes32 hookHash, bytes memory hookSignature);
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `IPreValidationHook` interface to include a new external function that returns a `bytes32` hash and a `bytes` memory signature.

### Detailed summary
- Added an external function to the `IPreValidationHook` interface.
- The new function is marked as `view`.
- It returns two values: `bytes32 hookHash` and `bytes memory hookSignature`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->