### PR TITLE
[Nexus 1.2.0] Init Nexus with default validator and other modules 

### DIFF
--- a/contracts/utils/NexusBootstrap.sol
+++ b/contracts/utils/NexusBootstrap.sol
@@ -70,7 +70,10 @@ contract NexusBootstrap is ModuleManager {
     )
         external
         payable
+        _withInitSentinelLists
     {
+        _configureRegistry(registry, attesters, threshold);
+
         IModule(_DEFAULT_VALIDATOR).onInstall(defaultValidatorInitData);
 
         for (uint256 i = 0; i < executors.length; i++) {


### PR DESCRIPTION
Add flow to init Nexus with default validator and other modules

Fixes issue: https://github.com/zenith-security/2025-03-biconomy-nexus/issues/2

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new function, `initNexusWithDefaultValidatorAndOtherModules`, to the `NexusBootstrap` contract. This function initializes the Nexus with a default validator, executors, a hook, and fallback handlers, enhancing module management.

### Detailed summary
- Added `initNexusWithDefaultValidatorAndOtherModules` function.
- Accepts parameters for default validator init data, executors, hook, fallbacks, registry, attesters, and threshold.
- Configures the registry with `_configureRegistry`.
- Installs the default validator using `IModule(_DEFAULT_VALIDATOR).onInstall`.
- Iterates through `executors` to install each executor module.
- Installs a hook if provided.
- Iterates through `fallbacks` to install each fallback handler.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->