### PR TITLE
[Nexus 1.2.0] Prevent double hooking

### DIFF
--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -59,6 +59,10 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
     using ExcessivelySafeCall for address;
     using ECDSA for bytes32;
 
+    /// @dev The slot in the transient storage to store the hooking flag.
+    // keccak256("nexus.modulemanager.hooking")
+    bytes32 internal constant HOOKING_FLAG_TRANSIENT_STORAGE_SLOT = 0xe4a29a8042309a2ad08ae7c52d833b9d6166e6e098a4b7bfa75a8bad5472586d;
+
     /// @dev The default validator address.
     /// @notice To initialize the default validator, Nexus.execute(_DEFAULT_VALIDATOR.onInstall(...)) should be called.
     address internal immutable _DEFAULT_VALIDATOR;
@@ -81,9 +85,16 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
     /// @dev sender, msg.data and msg.value is passed to the hook to implement custom flows.
     modifier withHook() {
         address hook = _getHook();
-        if (hook == address(0)) {
+        bool hooking;
+        assembly {
+            hooking := tload(HOOKING_FLAG_TRANSIENT_STORAGE_SLOT)
+        }
+        if (hook == address(0) || hooking) {
             _;
         } else {
+            assembly {
+                tstore(HOOKING_FLAG_TRANSIENT_STORAGE_SLOT, 1)
+            }
             bytes memory hookData = IHook(hook).preCheck(msg.sender, msg.value, msg.data);
             _;
             IHook(hook).postCheck(hookData);

--- a/contracts/mocks/MockHook.sol
+++ b/contracts/mocks/MockHook.sol
@@ -10,6 +10,8 @@ contract MockHook is IModule {
     event PostCheckCalled();
     event HookOnInstallCalled(bytes32 dataFirstWord);
 
+    uint256 public a;
+
     function onInstall(bytes calldata data) external override {
         if (data.length >= 0x20) {
             emit HookOnInstallCalled(bytes32(data[0:32]));
@@ -22,6 +24,8 @@ contract MockHook is IModule {
 
     function preCheck(address sender, uint256 value, bytes calldata data) external returns (bytes memory) {
         emit PreCheckCalled();
+
+        a++;
 
         // Add a condition to revert if the sender is the zero address or if the value is 1 ether for testing purposes
         if (value == 1 ether) {
@@ -42,5 +46,13 @@ contract MockHook is IModule {
 
     function isInitialized(address) external pure returns (bool) {
         return false;
+    }
+
+    function getA() external view returns (uint256) {
+        return a;
+    }
+
+    function cleanA() external {
+        a = 0;
     }
 }

--- a/contracts/mocks/MockMultiModule.sol
+++ b/contracts/mocks/MockMultiModule.sol
@@ -7,7 +7,11 @@ import { PackedUserOperation } from "account-abstraction/interfaces/PackedUserOp
 import { ECDSA } from "solady/utils/ECDSA.sol";
 import { SignatureCheckerLib } from "solady/utils/SignatureCheckerLib.sol";
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+import { IERC7579Account } from "contracts/interfaces/IERC7579Account.sol";
+import { ExecLib } from "contracts/lib/ExecLib.sol";
+import { ModeLib } from "contracts/lib/ModeLib.sol";
 import "../types/Constants.sol";
+import { Execution } from "../types/DataTypes.sol";
 
 contract MockMultiModule is IModule {
     mapping(uint256 moduleTypeId => mapping(address smartAccount => bytes32 initData)) configs;
@@ -15,6 +19,13 @@ contract MockMultiModule is IModule {
     function validateUserOp(PackedUserOperation calldata userOp, bytes32 userOpHash) external view returns (uint256 validation) {
         address owner = address(bytes20(configs[MODULE_TYPE_VALIDATOR][msg.sender]));
         return ECDSA.recover(MessageHashUtils.toEthSignedMessageHash(userOpHash), userOp.signature) == owner ? VALIDATION_SUCCESS : VALIDATION_FAILED;
+    }
+
+    function someFallbackFunction(Execution calldata execution) external {
+        IERC7579Account(msg.sender).executeFromExecutor{value: execution.value}({
+                    mode: ModeLib.encodeSimpleSingle(),
+                    executionCalldata: ExecLib.encodeSingle(execution.target, execution.value, execution.callData)
+                });
     }
 
     function getConfig(address smartAccount, uint256 moduleTypeId) external view returns (bytes32) {
@@ -26,7 +37,7 @@ contract MockMultiModule is IModule {
             uint256 moduleTypeId = uint256(uint8(bytes1(data[:1])));
             configs[moduleTypeId][msg.sender] = bytes32(data[1:33]);
         } else {
-            revert("MultiModule: Wrong install Data");
+            
         }
     }
 

--- a/test/foundry/unit/concrete/modulemanager/TestModuleManager_FallbackHandler.t.sol
+++ b/test/foundry/unit/concrete/modulemanager/TestModuleManager_FallbackHandler.t.sol
@@ -15,10 +15,12 @@ contract TestModuleManager_FallbackHandler is TestModuleManagement_Base {
 
     MockNFT internal erc721;
     MockERC1155 internal erc1155;
+    Counter internal counter;
     
     function setUp() public {
         init();
 
+        counter = new Counter();
         erc721 = new MockNFT("Mock NFT", "MNFT");
         erc1155 = new MockERC1155("Test");
 
@@ -405,4 +407,50 @@ contract TestModuleManager_FallbackHandler is TestModuleManagement_Base {
         bytes memory result2 = IHandler(address(BOB_ACCOUNT)).returnBytes();
         assertEq(result2, expectedResult);
     }
+
+    function test_No_Double_Hooking() public {
+        MockMultiModule multiModule = new MockMultiModule();
+
+        bytes memory customData = abi.encode(bytes5(abi.encodePacked(bytes4(0x0d50031f), CALLTYPE_SINGLE)));
+        bytes memory callData = abi.encodeWithSelector(
+            IModuleManager.installModule.selector,
+            MODULE_TYPE_FALLBACK,
+            address(multiModule),
+            customData
+        );
+
+        bytes memory callData2 = abi.encodeWithSelector(
+            IModuleManager.installModule.selector,
+            MODULE_TYPE_EXECUTOR,
+            address(multiModule),
+            ""
+        );
+
+        Execution[] memory executions = new Execution[](2);
+        executions[0] = Execution(address(BOB_ACCOUNT), 0, callData);
+        executions[1] = Execution(address(BOB_ACCOUNT), 0, callData2);
+        PackedUserOperation[] memory userOps = buildPackedUserOperation(BOB, BOB_ACCOUNT, EXECTYPE_DEFAULT, executions, address(VALIDATOR_MODULE), 0);
+        ENTRYPOINT.handleOps(userOps, payable(address(BOB.addr)));
+
+        assertEq(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_FALLBACK, address(multiModule), customData), true);
+        assertEq(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_EXECUTOR, address(multiModule), ""), true);
+
+        Execution memory execution = Execution(address(counter), 0, abi.encodeWithSelector(Counter.incrementNumber.selector));
+
+        uint256 hookUsedBefore = HOOK_MODULE.getA();
+        assertEq(counter.getNumber(), 0);
+        
+        vm.startPrank(address(ENTRYPOINT));
+        vm.expectEmit(true, true, true, true, address(HOOK_MODULE));
+        emit PreCheckCalled();
+        ISomeFallbackFunction(address(BOB_ACCOUNT)).someFallbackFunction(execution);
+        vm.stopPrank();
+
+        assertEq(HOOK_MODULE.getA(), hookUsedBefore + 1);
+        assertEq(counter.getNumber(), 1);
+    }     
+}
+
+interface ISomeFallbackFunction {
+    function someFallbackFunction(Execution calldata execution) external;
 }


### PR DESCRIPTION
As per https://github.com/zenith-security/2025-03-biconomy/issues/3

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces new functionality and enhancements in the `MockHook`, `ModuleManager`, and `MockMultiModule` contracts, including state management, new event emissions, and additional fallback handling in tests.

### Detailed summary
- Added `uint256 public a;` and methods `getA()` and `cleanA()` in `MockHook`.
- Emitted `HookOnInstallCalled` event in `onInstall()`.
- Introduced transient storage for hooking flag in `ModuleManager`.
- Updated `withHook` modifier to handle hooking logic.
- Added `someFallbackFunction()` in `MockMultiModule`.
- Enhanced test coverage in `TestModuleManager_FallbackHandler` for double hooking scenarios.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->