### PR TITLE
[Nexus 1.2.0] Fix DEFAULT_VALIDATOR usage issues and leftover owners[userOp.sender]

### DIFF
--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -116,31 +116,26 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
     {
         address validator;
         PackedUserOperation memory userOp = op;
-        if (op.nonce.isDefaultValidatorMode()) {
-            validator = _DEFAULT_VALIDATOR;
-        } else {
-            if (op.nonce.isValidateMode()) {
-                // do nothing special. This is introduced
-                // to quickly identify the most commonly used 
-                // mode which is validate mode
-                // and avoid checking two above conditions
-            } else if (op.nonce.isModuleEnableMode()) {
-                // if it is module enable mode, we need to enable the module first
-                // and get the cleaned signature
-                userOp.signature = _enableMode(userOpHash, op.signature);  
-            } else if (op.nonce.isPrepMode()) {
-                // PREP Mode. Authorize prep signature
-                // and initialize the account
-                // PREP mode is only used for the uninited PREPs
-                require(!isInitialized(), AccountAlreadyInitialized());
-                bytes calldata initData;
-                (userOp.signature, initData) = _handlePREP(op.signature);
-                _initializeAccount(initData);
-            }
-            validator = op.nonce.getValidator();
-            require(_isValidatorInstalled(validator), ValidatorNotInstalled(validator));
+    
+        if (op.nonce.isValidateMode()) {
+            // do nothing special. This is introduced
+            // to quickly identify the most commonly used 
+            // mode which is validate mode
+            // and avoid checking two above conditions
+        } else if (op.nonce.isModuleEnableMode()) {
+            // if it is module enable mode, we need to enable the module first
+            // and get the cleaned signature
+            userOp.signature = _enableMode(userOpHash, op.signature);
+        } else if (op.nonce.isPrepMode()) {
+            // PREP Mode. Authorize prep signature
+            // and initialize the account
+            // PREP mode is only used for the uninited PREPs
+            require(!isInitialized(), AccountAlreadyInitialized());
+            bytes calldata initData;
+            (userOp.signature, initData) = _handlePREP(op.signature);
+            _initializeAccount(initData);
         }
-        
+        validator = _handleValidator(op.nonce.getValidator());
         (userOpHash, userOp.signature) = _withPreValidationHook(userOpHash, userOp, missingAccountFunds);
         validationData = IValidator(validator).validateUserOp(userOp, userOpHash);
     }
@@ -303,6 +298,7 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
 
         address bootstrap;
         bytes calldata bootstrapCall;
+
         assembly {
             bootstrap := calldataload(initData.offset)
             let s := calldataload(add(initData.offset, 0x20))
@@ -310,13 +306,13 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
             bootstrapCall.offset := add(u, 0x20)
             bootstrapCall.length := calldataload(u)
         }
+
         (bool success, ) = bootstrap.delegatecall(bootstrapCall);
 
         require(success, NexusInitializationFailed());
-        // _hasValidators check removed as with 7702 even if there's no validator installed,
-        // the account is still initializeable.
-        // Checking all the possible cases of whether account is initializeable or initialized
-        // is too gas heavy, so it's initializing party responsibility to provide valid initData.
+        if(!_amIERC7702()) {
+            require(isInitialized(), AccountNotInitialized());
+        }
     }
 
     /// @notice Sets the registry for the smart account.
@@ -344,7 +340,7 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
         }
         // else proceed with normal signature verification
         // First 20 bytes of data will be validator address and rest of the bytes is complete signature.
-        address validator = _handleSigValidator(address(bytes20(signature[0:20]))); 
+        address validator = _handleValidator(address(bytes20(signature[0:20]))); 
         bytes memory signature_;
         (hash, signature_) = _withPreValidationHook(hash, signature[20:]);
         try IValidator(validator).isValidSignatureWithSender(msg.sender, hash, signature_) returns (bytes4 res) {
@@ -458,14 +454,20 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
             SentinelListLib.SentinelList storage validators = _getAccountStorage().validators;
             address next = validators.entries[SENTINEL];
             while (next != ZERO_ADDRESS && next != SENTINEL) {
-                bytes4 support = IValidator(next).isValidSignatureWithSender(msg.sender, hash, signature);
-                if (bytes2(support) == bytes2(SUPPORTS_ERC7739) && support > result) {
-                    result = support;
-                }
+                result = _get7739Version(next, result, hash, signature);
                 next = validators.getNext(next);
             }
         }
+        result = _get7739Version(_DEFAULT_VALIDATOR, result, hash, signature); // check default validator
         return result == bytes4(0) ? bytes4(0xffffffff) : result;
+    }
+
+    function _get7739Version(address validator, bytes4 prevResult, bytes32 hash, bytes calldata signature) internal view returns (bytes4) {
+        bytes4 support = IValidator(validator).isValidSignatureWithSender(msg.sender, hash, signature);
+        if (bytes2(support) == bytes2(SUPPORTS_ERC7739) && support > prevResult) {
+            return support;
+        }
+        return prevResult;
     }
 
     /// @dev Ensures that only authorized callers can upgrade the smart contract implementation.

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -412,8 +412,7 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
     /// @param data The emergency uninstall data.
     /// @param signature The signature to validate.
     function _checkEmergencyUninstallSignature(EmergencyUninstall calldata data, bytes calldata signature) internal {
-        address validator = address(bytes20(signature[0:20]));
-        require(_isValidatorInstalled(validator), ValidatorNotInstalled(validator));
+        address validator = _handleValidator(address(bytes20(signature[0:20])));
         // Hash the data
         bytes32 hash = _getEmergencyUninstallDataHash(data.hook, data.hookType, data.deInitData, data.nonce);
         // Check if nonce is valid

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -34,8 +34,7 @@ import {
     MODULE_TYPE_MULTI,
     MODULE_ENABLE_MODE_TYPE_HASH,
     EMERGENCY_UNINSTALL_TYPE_HASH,
-    ERC1271_MAGICVALUE,
-    DEFAULT_VALIDATOR_FLAG
+    ERC1271_MAGICVALUE
 } from "../types/Constants.sol";
 import { EIP712 } from "solady/utils/EIP712.sol";
 import { ExcessivelySafeCall } from "excessively-safe-call/ExcessivelySafeCall.sol";
@@ -60,7 +59,7 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
     using ECDSA for bytes32;
 
     /// @dev The default validator address.
-    /// @notice To initialize the default validator, Nexus.execute(_DEFAULT_VALIDATOR.onInstall(...)) should be called.
+    /// @notice To explicitly initialize the default validator, Nexus.execute(_DEFAULT_VALIDATOR.onInstall(...)) should be called.
     address internal immutable _DEFAULT_VALIDATOR;
 
     /// @dev initData should block the implementation from being used as a Smart Account
@@ -154,7 +153,7 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
 
         (module, moduleType, moduleInitData, enableModeSignature, userOpSignature) = packedData.parseEnableModeData();
 
-        address enableModeSigValidator = _handleSigValidator(address(bytes20(enableModeSignature[0:20])));
+        address enableModeSigValidator = _handleValidator(address(bytes20(enableModeSignature[0:20])));
         
         enableModeSignature = enableModeSignature[20:];
         
@@ -607,8 +606,8 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
     }
 
     /// @dev Returns the validator address to use
-    function _handleSigValidator(address validator) internal view returns (address) {
-        if (validator == DEFAULT_VALIDATOR_FLAG) {
+    function _handleValidator(address validator) internal view returns (address) {
+        if (validator == address(0)) {
             return _DEFAULT_VALIDATOR;
         } else {
             require(_isValidatorInstalled(validator), ValidatorNotInstalled(validator));

--- a/contracts/interfaces/INexusEventsAndErrors.sol
+++ b/contracts/interfaces/INexusEventsAndErrors.sol
@@ -62,4 +62,7 @@ interface INexusEventsAndErrors {
 
     /// @notice Error thrown when the account is already initialized.
     error AccountAlreadyInitialized();
+
+    /// @notice Error thrown when the account is not initialized but expected to be.
+    error AccountNotInitialized();
 }

--- a/contracts/lib/NonceLib.sol
+++ b/contracts/lib/NonceLib.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.27;
 
-import { MODE_MODULE_ENABLE, MODE_DEFAULT_VALIDATOR, MODE_PREP, MODE_VALIDATION } from "../types/Constants.sol";
+import { MODE_MODULE_ENABLE, MODE_PREP, MODE_VALIDATION } from "../types/Constants.sol";
 
 /**
     Nonce structure
@@ -28,13 +28,13 @@ library NonceLib {
         }
     }
 
-    /// @dev Detects if Validaton Mode is Default Validator Mode
+    /// @dev Detects if the validator provided in the nonce is address(0)
+    /// which means the default validator is used
     /// @param nonce The nonce
     /// @return res boolean result, true if it is the Default Validator Mode
     function isDefaultValidatorMode(uint256 nonce) internal pure returns (bool res) {
         assembly {
-            let vmode := byte(3, nonce)
-            res := eq(shl(248, vmode), MODE_DEFAULT_VALIDATOR)
+            res := iszero(shr(96, shl(32, nonce)))
         }
     }
 

--- a/contracts/modules/validators/K1Validator.sol
+++ b/contracts/modules/validators/K1Validator.sol
@@ -139,7 +139,7 @@ contract K1Validator is IValidator, ERC7739Validator {
      * for more details)
      */
     function validateUserOp(PackedUserOperation calldata userOp, bytes32 userOpHash) external view override returns (uint256) {
-        return _validateSignatureForOwner(smartAccountOwners[userOp.sender], userOpHash, userOp.signature) ? VALIDATION_SUCCESS : VALIDATION_FAILED;
+        return _validateSignatureForOwner(getOwner(userOp.sender), userOpHash, userOp.signature) ? VALIDATION_SUCCESS : VALIDATION_FAILED;
     }
 
     /**

--- a/contracts/types/Constants.sol
+++ b/contracts/types/Constants.sol
@@ -53,11 +53,7 @@ bytes32 constant EMERGENCY_UNINSTALL_TYPE_HASH = 0xd3ddfc12654178cc44d4a7b6b969c
 // Validation modes
 bytes1 constant MODE_VALIDATION = 0x00;
 bytes1 constant MODE_MODULE_ENABLE = 0x01;
-bytes1 constant MODE_DEFAULT_VALIDATOR = 0x02;
-bytes1 constant MODE_PREP = 0x03;
-
-// The flag to indicate the default validator mode for enable mode signature
-address constant DEFAULT_VALIDATOR_FLAG = 0x0000000000000000000000000000000000000088;
+bytes1 constant MODE_PREP = 0x02;
 
 bytes4 constant SUPPORTS_ERC7739 = 0x77390000;
 bytes4 constant SUPPORTS_ERC7739_V1 = 0x77390001;

--- a/contracts/utils/NexusBootstrap.sol
+++ b/contracts/utils/NexusBootstrap.sol
@@ -22,6 +22,8 @@ import {
     MODULE_TYPE_HOOK
 } from "../types/Constants.sol";
 
+import { console2 } from "forge-std/console2.sol";
+
 /// @title NexusBootstrap Configuration for Nexus
 /// @notice Provides configuration and initialization for Nexus smart accounts.
 /// @author @livingrockrises | Biconomy | chirag@biconomy.io
@@ -56,6 +58,7 @@ contract NexusBootstrap is ModuleManager {
         external
         payable
     {
+        console2.log("initNexusWithDefaultValidator");
         IModule(_DEFAULT_VALIDATOR).onInstall(data);
     }
 

--- a/contracts/utils/NexusBootstrap.sol
+++ b/contracts/utils/NexusBootstrap.sol
@@ -22,8 +22,6 @@ import {
     MODULE_TYPE_HOOK
 } from "../types/Constants.sol";
 
-import { console2 } from "forge-std/console2.sol";
-
 /// @title NexusBootstrap Configuration for Nexus
 /// @notice Provides configuration and initialization for Nexus smart accounts.
 /// @author @livingrockrises | Biconomy | chirag@biconomy.io
@@ -58,7 +56,6 @@ contract NexusBootstrap is ModuleManager {
         external
         payable
     {
-        console2.log("initNexusWithDefaultValidator");
         IModule(_DEFAULT_VALIDATOR).onInstall(data);
     }
 

--- a/test/foundry/unit/concrete/eip7702/TestEIP7702.t.sol
+++ b/test/foundry/unit/concrete/eip7702/TestEIP7702.t.sol
@@ -54,7 +54,7 @@ contract TestEIP7702 is NexusTest_Base {
         address account = vm.addr(eoaKey);
         vm.deal(account, 100 ether);
 
-        uint256 nonce = getNonce(account, MODE_DEFAULT_VALIDATOR, address(mockValidator), 0);
+        uint256 nonce = getNonce(account, MODE_VALIDATION, address(0), 0);
 
         // Create the userOp and add the data
         PackedUserOperation memory userOp = buildPackedUserOp(address(account), nonce);
@@ -93,7 +93,7 @@ contract TestEIP7702 is NexusTest_Base {
         // Encode the call into the calldata for the userOp
         bytes memory userOpCalldata = abi.encodeCall(IExecutionHelper.execute, (ModeLib.encodeSimpleBatch(), ExecLib.encodeBatch(executions)));
 
-        uint256 nonce = getNonce(account, MODE_DEFAULT_VALIDATOR, address(0), 0);
+        uint256 nonce = getNonce(account, MODE_VALIDATION, address(0), 0);
 
         // Create the userOp and add the data
         PackedUserOperation memory userOp = buildPackedUserOp(address(account), nonce);
@@ -133,7 +133,7 @@ contract TestEIP7702 is NexusTest_Base {
         address account = vm.addr(eoaKey);
         vm.deal(account, 100 ether);
 
-        uint256 nonce = getNonce(account, MODE_DEFAULT_VALIDATOR, address(mockValidator), 0);
+        uint256 nonce = getNonce(account, MODE_VALIDATION, address(0), 0);
 
         // Create the userOp and add the data
         PackedUserOperation memory userOp = buildPackedUserOp(address(account), nonce);
@@ -198,7 +198,7 @@ contract TestEIP7702 is NexusTest_Base {
         address account = vm.addr(eoaKey);
         vm.deal(account, 100 ether);
 
-        uint256 nonce = getNonce(account, MODE_DEFAULT_VALIDATOR, address(mockValidator), 0);
+        uint256 nonce = getNonce(account, MODE_VALIDATION, address(0), 0);
 
         // Create the userOp and add the data
         PackedUserOperation memory userOp = buildPackedUserOp(address(account), nonce);

--- a/test/foundry/unit/concrete/modulemanager/TestModuleManager_EnableMode.t.sol
+++ b/test/foundry/unit/concrete/modulemanager/TestModuleManager_EnableMode.t.sol
@@ -175,7 +175,7 @@ contract TestModuleManager_EnableMode is Test, TestModuleManagement_Base {
         (bytes memory multiInstallData, bytes32 hashToSign, ) = makeInstallDataAndHash(BOB_ADDRESS, MODULE_TYPE_MULTI, userOpHash);
 
         bytes memory enableModeSig = signMessage(BOB, hashToSign); //should be signed by current owner
-        enableModeSig = abi.encodePacked(DEFAULT_VALIDATOR_FLAG, enableModeSig); //append validator address
+        enableModeSig = abi.encodePacked(address(0), enableModeSig); //append validator address
 
         bytes memory enableModeSigPrefix = abi.encodePacked(
             moduleToEnable,

--- a/test/foundry/unit/fuzz/TestFuzz_ERC4337Account.t.sol
+++ b/test/foundry/unit/fuzz/TestFuzz_ERC4337Account.t.sol
@@ -57,34 +57,6 @@ contract TestFuzz_ERC4337Account is NexusTest_Base {
         }
     }
 
-    /// @notice Fuzz testing for validating user operations with random nonces and signatures.
-    /// @param randomNonce A random nonce value.
-    /// @param randomSignature A random signature.
-    function testFuzz_ValidateUserOp(uint256 randomNonce, bytes memory randomSignature) public {
-        vm.deal(address(ENTRYPOINT), 10 ether); // Ensure the ENTRYPOINT has enough ether to cover transaction fees
-        vm.assume(randomNonce < type(uint192).max); // Assuming practical nonce range
-
-        // Create a user operation with random data
-        PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
-        userOps[0] = buildPackedUserOp(userAddress, randomNonce);
-        bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
-        userOps[0].signature = randomSignature; // Using fuzzed signature
-
-        address validator;
-
-        assembly {
-            validator := shr(96, shl(32, randomNonce))
-        }
-
-        // Expect revert with ValidatorNotInstalled selector
-        vm.expectRevert(abi.encodeWithSelector(ValidatorNotInstalled.selector, validator));
-
-        // Attempt to validate the user operation
-        startPrank(address(ENTRYPOINT));
-        BOB_ACCOUNT.validateUserOp(userOps[0], userOpHash, 10);
-        stopPrank();
-    }
-
     /// @notice Fuzz testing for withdrawing deposits to a specific address.
     /// @param to The address to withdraw to.
     /// @param amount The amount to withdraw.
@@ -110,29 +82,6 @@ contract TestFuzz_ERC4337Account is NexusTest_Base {
         executeBatch(BOB, BOB_ACCOUNT, withdrawExecutions, EXECTYPE_DEFAULT);
 
         assertEq(to.balance, amount, "Withdrawal amount should reflect in the 'to' address balance");
-    }
-
-    /// @notice Fuzz testing for validating user operations with invalid signatures.
-    /// @param randomNonce A random nonce value.
-    /// @param invalidSignature An invalid signature.
-    function testFuzz_InvalidSignature(uint256 randomNonce, bytes memory invalidSignature) public {
-        vm.assume(randomNonce < type(uint192).max); // Assuming practical nonce range
-
-        PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
-        userOps[0] = buildPackedUserOp(userAddress, randomNonce);
-        bytes32 userOpHash = ENTRYPOINT.getUserOpHash(userOps[0]);
-        userOps[0].signature = invalidSignature; // Using invalid signature
-        address validator;
-
-        assembly {
-            validator := shr(96, shl(32, randomNonce))
-        }
-        // Expect revert with ValidatorNotInstalled selector
-        vm.expectRevert(abi.encodeWithSelector(ValidatorNotInstalled.selector, validator));
-
-        startPrank(address(ENTRYPOINT));
-        BOB_ACCOUNT.validateUserOp(userOps[0], userOpHash, 10);
-        stopPrank();
     }
 
     /// @notice Fuzz testing for withdrawing deposits with insufficient funds.

--- a/test/foundry/utils/TestHelper.t.sol
+++ b/test/foundry/utils/TestHelper.t.sol
@@ -29,6 +29,7 @@ import { BootstrapLib } from "../../../contracts/lib/BootstrapLib.sol";
 import { MockRegistry } from "../../../contracts/mocks/MockRegistry.sol";
 import { EIP712 } from "solady/utils/EIP712.sol";
 import "../../../contracts/types/Constants.sol";
+import { K1Validator } from "../../../contracts/modules/validators/K1Validator.sol";
 
 contract TestHelper is CheatCodes, EventsAndErrors {
 
@@ -68,7 +69,7 @@ contract TestHelper is CheatCodes, EventsAndErrors {
     MockHandler internal HANDLER_MODULE;
     MockExecutor internal EXECUTOR_MODULE;
     MockValidator internal VALIDATOR_MODULE;
-    MockValidator internal DEFAULT_VALIDATOR_MODULE;
+    K1Validator internal DEFAULT_VALIDATOR_MODULE;
     MockMultiModule internal MULTI_MODULE;
     Nexus internal ACCOUNT_IMPLEMENTATION;
 
@@ -115,7 +116,7 @@ contract TestHelper is CheatCodes, EventsAndErrors {
 
     function deployTestContracts() internal {
         setupEntrypoint();
-        DEFAULT_VALIDATOR_MODULE = new MockValidator();
+        DEFAULT_VALIDATOR_MODULE = new K1Validator();
         // This is the implementation of the account => default module initialized with an unusable configuration
         ACCOUNT_IMPLEMENTATION = new Nexus(address(ENTRYPOINT), address(DEFAULT_VALIDATOR_MODULE), abi.encodePacked(address(0xeEeEeEeE)));
         FACTORY = new NexusAccountFactory(address(ACCOUNT_IMPLEMENTATION), address(FACTORY_OWNER.addr));


### PR DESCRIPTION
Fix issues:
https://github.com/zenith-security/2025-03-biconomy-nexus/issues/1
https://github.com/zenith-security/2025-03-biconomy-nexus/issues/8
https://github.com/zenith-security/2025-03-biconomy-nexus/issues/9
https://github.com/zenith-security/2025-03-biconomy-nexus/issues/11
https://github.com/zenith-security/2025-03-biconomy-nexus/issues/12

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new error for uninitialized accounts, modifies validator handling, and updates the default validator implementation. It also refines nonce handling and improves the validation process for user operations.

### Detailed summary
- Added `AccountNotInitialized` error.
- Changed validator handling to use `address(0)` for default validator.
- Updated `validateUserOp` to fetch owner using `getOwner`.
- Removed `MODE_DEFAULT_VALIDATOR` and adjusted constants.
- Updated `isDefaultValidatorMode` to check for `address(0)`.
- Replaced `MockValidator` with `K1Validator` in tests.
- Enhanced nonce handling in user operation validation.
- Removed fuzz tests for invalid signatures and nonces.
- Adjusted Nexus contract logic for validator checks and initialization.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->