### PR TITLE
[Nexus 1.2.0] Fix issues 4,5,6 Zenith 

### DIFF
--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -175,6 +175,8 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
     /// - 2 for Executor
     /// - 3 for Fallback
     /// - 4 for Hook
+    /// - 8 for PreValidationHookERC1271
+    /// - 9 for PreValidationHookERC4337
     /// @param module The address of the module to install.
     /// @param initData Initialization data for the module.
     /// @dev This function goes through hook checks via withHook modifier.
@@ -600,7 +602,7 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
             if eq(extcodesize(address()), 23) {
                 // use extcodecopy to copy first 3 bytes of this contract and compare with 0xef0100
                 extcodecopy(address(), 0, 0, 3)
-                res := eq(0xef01, shr(240, mload(0x00)))
+                res := eq(0xef0100, shr(232, mload(0x00)))
             }
             // if it is not 23, we do not even check the first 3 bytes
         }

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -349,7 +349,6 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
     /// @param data De-initialization data to configure the hook upon uninstallation.
     function _uninstallPreValidationHook(address preValidationHook, uint256 hookType, bytes calldata data) internal virtual {
         _setPreValidationHook(hookType, address(0));
-        preValidationHook.excessivelySafeCall(gasleft(), 0, 0, abi.encodeWithSelector(IModule.onUninstall.selector, data));
     }
 
     /// @dev Sets the current pre-validation hook in the storage to the specified address, based on the hook type.


### PR DESCRIPTION
- https://github.com/zenith-security/2025-03-biconomy-nexus/issues/4
- https://github.com/zenith-security/2025-03-biconomy-nexus/issues/5
- https://github.com/zenith-security/2025-03-biconomy-nexus/issues/6

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `ModuleManager` contract by adding new pre-validation hooks and correcting a byte comparison in a conditional check.

### Detailed summary
- Added documentation for new pre-validation hooks: `PreValidationHookERC1271` and `PreValidationHookERC4337`.
- Updated the `_uninstallPreValidationHook` function by removing a call to `excessivelySafeCall`.
- Corrected the byte comparison from `0xef01` to `0xef0100` in the conditional check.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->