### PR TITLE
[Nexus 1.2.0] Always hook set registry

### DIFF
--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -324,7 +324,8 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
     /// @param attesters The attesters to set.
     /// @param threshold The threshold to set.
     /// @dev This function can only be called by the EntryPoint or the account itself.
-    function setRegistry(IERC7484 newRegistry, address[] calldata attesters, uint8 threshold) external payable onlyEntryPointOrSelf {
+    function setRegistry(IERC7484 newRegistry, address[] calldata attesters, uint8 threshold) external payable {
+        require(msg.sender == address(this), AccountAccessUnauthorized());
         _configureRegistry(newRegistry, attesters, threshold);
     }
 


### PR DESCRIPTION
If called by EP, setRegistry won't be not hooked, which means owner could update the registry and make the claims revert for the solvers if Nexus is used with resource locks

<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the `setRegistry` function in the `Nexus.sol` contract to remove the access control modifier and enforce that only the contract itself can call the function.

### Detailed summary
- Removed the `onlyEntryPointOrSelf` modifier from the `setRegistry` function.
- Added a `require` statement to ensure that `msg.sender` is the contract itself.
- The function still configures the registry using `_configureRegistry`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->