### PR TITLE
[Nexus 1.2.0] No Registry methods in NexusBootstrap

### DIFF
--- a/contracts/base/RegistryAdapter.sol
+++ b/contracts/base/RegistryAdapter.sol
@@ -25,7 +25,7 @@ abstract contract RegistryAdapter {
     /// @param newRegistry The new registry contract to use.
     /// @param attesters The list of attesters to trust.
     /// @param threshold The number of attestations required.
-    function _configureRegistry(IERC7484 newRegistry, address[] calldata attesters, uint8 threshold) internal {
+    function _configureRegistry(IERC7484 newRegistry, address[] memory attesters, uint8 threshold) internal {
         registry = newRegistry;
         if (address(newRegistry) != address(0)) {
             newRegistry.trustAttesters(threshold, attesters);


### PR DESCRIPTION
Introducing methods that do not expect `registry`, `attesters` and `threshold` as arguments.
Having those will allow to save on calldata for the cases we do not want to enable registry, so no need to pass empty `address(0),` abi.encoded empty array and `uint256(0)`.