### PR TITLE
Fix [L-01] Use namespaced storage in RegistryAdapter

### DIFF
--- a/contracts/base/RegistryAdapter.sol
+++ b/contracts/base/RegistryAdapter.sol
@@ -2,12 +2,12 @@
 pragma solidity ^0.8.27;
 
 import { IERC7484 } from "../interfaces/IERC7484.sol";
+import { Storage } from "./Storage.sol";
 
 /// @title RegistryAdapter
 /// @notice This contract provides an interface for interacting with an ERC-7484 compliant registry.
 /// @dev The registry feature is opt-in, allowing the smart account owner to select and trust specific attesters.
-abstract contract RegistryAdapter {
-    IERC7484 public registry;
+abstract contract RegistryAdapter is Storage {
 
     /// @notice Emitted when a new ERC-7484 registry is configured for the account.
     /// @param registry The configured registry contract.
@@ -21,12 +21,18 @@ abstract contract RegistryAdapter {
         _;
     }
 
+    /// @notice Returns the configured ERC-7484 registry.
+    /// @return The configured registry contract.
+    function getRegistry() external view returns (IERC7484) {
+        return IERC7484(_getAccountStorage().registry);
+    }
+
     /// @notice Configures the ERC-7484 registry and sets trusted attesters.
     /// @param newRegistry The new registry contract to use.
     /// @param attesters The list of attesters to trust.
     /// @param threshold The number of attestations required.
     function _configureRegistry(IERC7484 newRegistry, address[] memory attesters, uint8 threshold) internal {
-        registry = newRegistry;
+        _getAccountStorage().registry = address(newRegistry);
         if (address(newRegistry) != address(0)) {
             newRegistry.trustAttesters(threshold, attesters);
         }
@@ -38,7 +44,7 @@ abstract contract RegistryAdapter {
     /// @param moduleType The type of the module to verify in the registry.
     /// @dev Reverts if the required attestations are not met.
     function _checkRegistry(address module, uint256 moduleType) internal view {
-        IERC7484 moduleRegistry = registry;
+        IERC7484 moduleRegistry = IERC7484(_getAccountStorage().registry);
         if (address(moduleRegistry) != address(0)) {
             // This will revert if attestations or the threshold are not met.
             moduleRegistry.check(module, moduleType);

--- a/contracts/interfaces/base/IStorage.sol
+++ b/contracts/interfaces/base/IStorage.sol
@@ -47,6 +47,8 @@ interface IStorage {
         IPreValidationHookERC1271 preValidationHookERC1271;
         ///< Mapping of used nonces for replay protection.
         mapping(uint256 => bool) nonces;
+        ///< ERC-7484 registry
+        address registry;
     }
 
     /// @notice Defines a fallback handler with an associated handler address and a call type.

--- a/test/hardhat/smart-account/Nexus.Basics.specs.ts
+++ b/test/hardhat/smart-account/Nexus.Basics.specs.ts
@@ -899,7 +899,7 @@ describe("Nexus Basic Specs", function () {
         .setRegistry(mockRegistry.getAddress(), attesters, threshold);
 
       // Verify the registry is set
-      const configuredRegistry = await smartAccount.registry();
+      const configuredRegistry = await smartAccount.getRegistry();
       expect(configuredRegistry).to.equal(await mockRegistry.getAddress());
 
       // Stop impersonating the smart account


### PR DESCRIPTION
https://github.com/PashovAuditGroup/Nexus_March25_MERGED/issues/2

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on integrating ERC-7484 registry functionality into the `RegistryAdapter` contract, enhancing how smart accounts can manage and interact with registries for attestation purposes.

### Detailed summary
- Added `registry` address mapping in `IStorage.sol` for ERC-7484.
- Updated `getRegistry()` function in `RegistryAdapter` to return the configured registry.
- Modified `_configureRegistry()` to store the new registry address in storage.
- Changed `registry` variable to use storage in `_checkRegistry()`.
- Updated test to call `getRegistry()` instead of directly accessing `registry`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->