### PR TITLE
Fix [M-01] Hook bypass for module installation via module enable mode

### DIFF
--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -228,7 +228,7 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
     /// @param initData Initialization data for the module.
     /// @dev This function can only be called by the EntryPoint or the account itself for security reasons.
     /// @dev This function goes through hook checks via withHook modifier through internal function _installModule.
-    function installModule(uint256 moduleTypeId, address module, bytes calldata initData) external payable onlyEntryPointOrSelf {
+    function installModule(uint256 moduleTypeId, address module, bytes calldata initData) external payable virtual override onlyEntryPointOrSelf {
         _installModule(moduleTypeId, module, initData);
         emit ModuleInstalled(moduleTypeId, module);
     }

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -23,7 +23,7 @@ import { IValidator } from "../interfaces/modules/IValidator.sol";
 import { CallType, CALLTYPE_SINGLE, CALLTYPE_STATIC } from "../lib/ModeLib.sol";
 import { ExecLib } from "../lib/ExecLib.sol";
 import { LocalCallDataParserLib } from "../lib/local/LocalCallDataParserLib.sol";
-import { IModuleManagerEventsAndErrors } from "../interfaces/base/IModuleManagerEventsAndErrors.sol";
+import { IModuleManager } from "../interfaces/base/IModuleManager.sol";
 import {
     MODULE_TYPE_VALIDATOR,
     MODULE_TYPE_EXECUTOR,
@@ -51,7 +51,7 @@ import { ECDSA } from "solady/utils/ECDSA.sol";
 /// @author @filmakarov | Biconomy | filipp.makarov@biconomy.io
 /// @author @zeroknots | Rhinestone.wtf | zeroknots.eth
 /// Special thanks to the Solady team for foundational contributions: https://github.com/Vectorized/solady
-abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndErrors, RegistryAdapter {
+abstract contract ModuleManager is Storage, EIP712, IModuleManager, RegistryAdapter {
     using SentinelListLib for SentinelListLib.SentinelList;
     using LocalCallDataParserLib for bytes;
     using ExecLib for address;
@@ -100,6 +100,7 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
         }
     }
 
+    // receive function
     receive() external payable { }
 
     /// @dev Fallback function to manage incoming calls using designated handlers based on the call type.
@@ -175,7 +176,7 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
         })) {
             revert EnableModeSigError();
         }
-        _installModule(moduleType, module, moduleInitData);
+        this.installModule(moduleType, module, moduleInitData);
     }
 
     /// @notice Installs a new module to the smart account.

--- a/contracts/interfaces/IERC7579Account.sol
+++ b/contracts/interfaces/IERC7579Account.sol
@@ -25,7 +25,7 @@ import { IModuleManager } from "./base/IModuleManager.sol";
 /// @author @filmakarov | Biconomy | filipp.makarov@biconomy.io
 /// @author @zeroknots | Rhinestone.wtf | zeroknots.eth
 /// Special thanks to the Solady team for foundational contributions: https://github.com/Vectorized/solady
-interface IERC7579Account is IAccountConfig, IExecutionHelper, IModuleManager {
+interface IERC7579Account is IAccountConfig, IExecutionHelper {
     /// @dev Validates a smart account signature according to ERC-1271 standards.
     /// This method may delegate the call to a validator module to check the signature.
     /// @param hash The hash of the data being validated.

--- a/contracts/mocks/EmittingHook.sol
+++ b/contracts/mocks/EmittingHook.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import { IModule } from "../interfaces/modules/IModule.sol";
+import { EncodedModuleTypes } from "../lib/ModuleTypeLib.sol";
+import "../types/Constants.sol";
+
+contract EmittingHook is IModule {
+    event PreCheckMsgData(bytes data);
+    event PreCheckExtractedSelector(bytes4 selector);
+    event PreCheckSender(address sender);
+    event PreCheckValue(uint256 value);
+    event HookOnInstallCalled(bytes32 dataFirstWord);
+    event PostCheckCalled();
+
+    function onInstall(bytes calldata data) external override {
+        if (data.length >= 0x20) {
+            emit HookOnInstallCalled(bytes32(data[0:32]));
+        }
+    }
+
+    function onUninstall(bytes calldata) external override {
+        emit PostCheckCalled();
+    }
+
+    function preCheck(address sender, uint256 value, bytes calldata data) external returns (bytes memory) {
+        bytes4 selector = bytes4(data[0:4]);
+        emit PreCheckExtractedSelector(selector);
+        emit PreCheckMsgData(data);
+        emit PreCheckSender(sender);
+        emit PreCheckValue(value);
+
+        return "";
+    }
+
+    function postCheck(bytes calldata hookData) external {
+        hookData;
+        emit PostCheckCalled();
+    }
+
+    function isModuleType(uint256 moduleTypeId) external pure returns (bool) {
+        return moduleTypeId == MODULE_TYPE_HOOK;
+    }
+
+    function isInitialized(address) external pure returns (bool) {
+        return false;
+    }
+}

--- a/contracts/utils/NexusBootstrap.sol
+++ b/contracts/utils/NexusBootstrap.sol
@@ -417,4 +417,18 @@ contract NexusBootstrap is ModuleManager {
         name = "NexusBootstrap";
         version = "1.2.0";
     }
+
+    
+    // required implementations. Are not used.
+    function installModule(uint256 moduleTypeId, address module, bytes calldata initData) external payable override {
+        // do nothing
+    }
+
+    function uninstallModule(uint256 moduleTypeId, address module, bytes calldata deInitData) external payable override {
+        // do nothing
+    }
+
+    function isModuleInstalled(uint256 moduleTypeId, address module, bytes calldata additionalContext) external view override returns (bool installed) {
+        return false;
+    }
 }

--- a/test/foundry/unit/concrete/factory/TestK1ValidatorFactory_Deployments.t.sol
+++ b/test/foundry/unit/concrete/factory/TestK1ValidatorFactory_Deployments.t.sol
@@ -125,7 +125,7 @@ contract TestK1ValidatorFactory_Deployments is NexusTest_Base {
         // Validate that the account was deployed correctly
         assertEq(deployedAccountAddress, expectedAddress, "Deployed account address mismatch");
 
-        assertEq(INexus(deployedAccountAddress).isModuleInstalled(MODULE_TYPE_VALIDATOR, address(VALIDATOR_MODULE), ""), true, "Validator should be installed");
+        assertEq(IModuleManager(deployedAccountAddress).isModuleInstalled(MODULE_TYPE_VALIDATOR, address(VALIDATOR_MODULE), ""), true, "Validator should be installed");
     }
 
     /// @notice Tests that computing the account address returns the expected address.

--- a/test/foundry/unit/concrete/factory/TestNexusAccountFactory_Deployments.t.sol
+++ b/test/foundry/unit/concrete/factory/TestNexusAccountFactory_Deployments.t.sol
@@ -226,11 +226,11 @@ contract TestNexusAccountFactory_Deployments is NexusTest_Base {
 
         // Verify that the validators and hook were installed
         assertTrue(
-            INexus(deployedAccountAddress).isModuleInstalled(MODULE_TYPE_VALIDATOR, address(VALIDATOR_MODULE), ""),
+            IModuleManager(deployedAccountAddress).isModuleInstalled(MODULE_TYPE_VALIDATOR, address(VALIDATOR_MODULE), ""),
             "Validator should be installed"
         );
         assertTrue(
-            INexus(deployedAccountAddress).isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), abi.encodePacked(user.addr)),
+            IModuleManager(deployedAccountAddress).isModuleInstalled(MODULE_TYPE_HOOK, address(HOOK_MODULE), abi.encodePacked(user.addr)),
             "Hook should be installed"
         );
     }


### PR DESCRIPTION
Fix https://github.com/PashovAuditGroup/Nexus_March25_MERGED/issues/13

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `ModuleManager` and related contracts by refining module installation functionalities, introducing a new `EmittingHook` contract, and updating interfaces for better modular management.

### Detailed summary
- Added `installModule`, `uninstallModule`, and `isModuleInstalled` functions in `NexusBootstrap`.
- Updated `IERC7579Account` interface to remove `IModuleManager`.
- Changed assertions in tests to use `IModuleManager`.
- Enhanced `installModule` method in `Nexus` to be `virtual override`.
- Introduced `EmittingHook` contract with various event emissions.
- Updated `ModuleManager` to utilize `IModuleManager`.
- Added a new test for module recognition by hooks in `TestModuleManager_EnableMode`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->