### PR TITLE
Fix [L-13] bypassing hooking with bootstrap

### DIFF
--- a/contracts/utils/NexusBootstrap.sol
+++ b/contracts/utils/NexusBootstrap.sol
@@ -269,17 +269,17 @@ contract NexusBootstrap is ModuleManager {
             emit ModuleInstalled(MODULE_TYPE_EXECUTOR, executors[i].module);
         }
 
-        // Initialize hook
-        if (hook.module != address(0)) {
-            _installHook(hook.module, hook.data);
-            emit ModuleInstalled(MODULE_TYPE_HOOK, hook.module);
-        }
-
         // Initialize fallback handlers
         for (uint256 i = 0; i < fallbacks.length; i++) {
             if (fallbacks[i].module == address(0)) continue;
             _installFallbackHandler(fallbacks[i].module, fallbacks[i].data);
             emit ModuleInstalled(MODULE_TYPE_FALLBACK, fallbacks[i].module);
+        }
+
+        // Initialize hook
+        if (hook.module != address(0)) {
+            _installHook(hook.module, hook.data);
+            emit ModuleInstalled(MODULE_TYPE_HOOK, hook.module);
         }
     }
 


### PR DESCRIPTION
Fix https://github.com/PashovAuditGroup/Nexus_March25_MERGED/issues/17

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the `ModuleManager` contract by adding the `withHook` modifier to various module installation functions, ensuring hooks are properly integrated during module installation processes.

### Detailed summary
- Added `withHook` modifier to the following functions:
  - `function _installModule`
  - `function _installValidator`
  - `function _installExecutor`
  - `function _installHook`
  - `function _installFallbackHandler`
- Maintained the existing functionality of each function while enhancing them with the `withHook` modifier.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->