### PR TITLE
Fix [255] Add event on ownership set to K1 Validator

### DIFF
--- a/contracts/modules/validators/K1Validator.sol
+++ b/contracts/modules/validators/K1Validator.sol
@@ -44,6 +44,9 @@ contract K1Validator is IValidator, ERC7739Validator {
 
     EnumerableSet.AddressSet private _safeSenders;
 
+    /// @notice Event emitted when the owner of a smart account is set
+    event OwnerSet(address indexed smartAccount, address indexed owner);
+
     /// @notice Error to indicate that no owner was provided during installation
     error NoOwnerProvided();
 
@@ -77,6 +80,7 @@ contract K1Validator is IValidator, ERC7739Validator {
         address newOwner = address(bytes20(data[:20]));
         require(newOwner != address(0), OwnerCannotBeZeroAddress());
         smartAccountOwners[msg.sender] = newOwner;
+        emit OwnerSet(msg.sender, newOwner);
         if (data.length > 20) {
             _fillSafeSenders(data[20:]);
         }
@@ -88,6 +92,7 @@ contract K1Validator is IValidator, ERC7739Validator {
     function onUninstall(bytes calldata) external override {
         delete smartAccountOwners[msg.sender];
         _safeSenders.removeAll(msg.sender);
+        emit OwnerSet(msg.sender, address(0));
     }
 
     /// @notice Transfers ownership of the validator to a new owner
@@ -95,6 +100,7 @@ contract K1Validator is IValidator, ERC7739Validator {
     function transferOwnership(address newOwner) external {
         require(newOwner != address(0), ZeroAddressNotAllowed());
         smartAccountOwners[msg.sender] = newOwner;
+        emit OwnerSet(msg.sender, newOwner);
     }
 
     /// @notice Adds a safe sender to the _safeSenders list for the smart account


### PR DESCRIPTION
Fix #255 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces an event for tracking ownership changes in the `K1Validator` contract and enhances the ownership management functionality.

### Detailed summary
- Added event `OwnerSet` to emit when a smart account's owner is set or changed.
- Introduced error `NoOwnerProvided` for cases where no owner is specified.
- Emitted `OwnerSet` event when a new owner is assigned and when ownership is removed during uninstallation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->