### PR TITLE
Add via-ir=true profile

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -19,12 +19,12 @@
   libs = ["node_modules", "lib"]
   gas_reports_ignore = ["MockToken"]
 
+[profile.via-ir]
+  via-ir = true
+
 [profile.ci]
   fuzz = { runs = 10_000 }
   verbosity = 4
-
-[profile.coverage]
-  via-ir = false
 
 [etherscan]
   arbitrum = { key = "${API_KEY_ARBISCAN}" }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `foundry.toml` configuration file by modifying profile settings for coverage and adding a new profile for `via-ir`.

### Detailed summary
- Removed the `via-ir` setting under the `[profile.coverage]` section, setting it to `false`.
- Added a new profile section `[profile.via-ir]` with `via-ir` set to `true`.
- Kept the existing configuration for `[profile.ci]` and `[etherscan]`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->