### PR TITLE
Fix [L-14] enable mode typehash

### DIFF
--- a/contracts/types/Constants.sol
+++ b/contracts/types/Constants.sol
@@ -44,8 +44,8 @@ uint256 constant MODULE_TYPE_PREVALIDATION_HOOK_ERC1271 = 8;
 uint256 constant MODULE_TYPE_PREVALIDATION_HOOK_ERC4337 = 9;
 
 
-// keccak256("ModuleEnableMode(address module,uint256 moduleType,bytes32 userOpHash,bytes32 initDataHash)")
-bytes32 constant MODULE_ENABLE_MODE_TYPE_HASH = 0xbe844ccefa05559a48680cb7fe805b2ec58df122784191aed18f9f315c763e1b;
+// keccak256("ModuleEnableMode(address module,uint256 moduleType,bytes32 userOpHash,bytes initData)")
+bytes32 constant MODULE_ENABLE_MODE_TYPE_HASH = 0xf6c866c1cd985ce61f030431e576c0e82887de0643dfa8a2e6efc3463e638ed0;
 
 // keccak256("EmergencyUninstall(address hook,uint256 hookType,bytes deInitData,uint256 nonce)")
 bytes32 constant EMERGENCY_UNINSTALL_TYPE_HASH = 0xd3ddfc12654178cc44d4a7b6b969cfdce7ffe6342326ba37825314cffa0fba9c;

--- a/test/foundry/unit/concrete/modulemanager/TestModuleManager_EnableMode.t.sol
+++ b/test/foundry/unit/concrete/modulemanager/TestModuleManager_EnableMode.t.sol
@@ -28,7 +28,7 @@ contract TestModuleManager_EnableMode is Test, TestModuleManagement_Base {
     MockResourceLockPreValidationHook private resourceLockHook;
     MockAccountLocker private accountLocker;
 
-    string constant MODULE_ENABLE_MODE_NOTATION = "ModuleEnableMode(address module,uint256 moduleType,bytes32 userOpHash,bytes32 initDataHash)";
+    string constant MODULE_ENABLE_MODE_NOTATION = "ModuleEnableMode(address module,uint256 moduleType,bytes32 userOpHash,bytes initData)";
 
     function setUp() public {
         setUpModuleManagement_Base();
@@ -553,7 +553,7 @@ contract TestModuleManager_EnableMode is Test, TestModuleManagement_Base {
 
         // prepare Enable Mode Signature
         structHash = keccak256(abi.encode(
-            MODULE_ENABLE_MODE_TYPE_HASH, 
+            keccak256(bytes(MODULE_ENABLE_MODE_NOTATION)), //type hash
             address(mockMultiModule),
             moduleType,
             userOpHash,


### PR DESCRIPTION
Fix https://github.com/PashovAuditGroup/Nexus_March25_MERGED/issues/18

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the type hash and notation for the `ModuleEnableMode` in the smart contract definitions, ensuring consistency between the constant values and their respective descriptions.

### Detailed summary
- Updated the `MODULE_ENABLE_MODE_TYPE_HASH` value to a new hash.
- Changed the `MODULE_ENABLE_MODE_NOTATION` to match the updated parameters.
- Adjusted the `keccak256` call in the `TestModuleManager_EnableMode` contract to use the new notation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->