### PR TITLE
Fix [L-09] modules may fail to be uninstalled

### DIFF
--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -226,7 +226,7 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
         IValidator(validator).onInstall(data);
     }
 
-    /// @dev Uninstalls a validator module /!\ ensuring the account retains at least one validator.
+    /// @dev Uninstalls a validator module.
     /// @param validator The address of the validator to be uninstalled.
     /// @param data De-initialization data to configure the validator upon uninstallation.
     function _uninstallValidator(address validator, bytes calldata data) internal virtual {


### PR DESCRIPTION
Fix https://github.com/PashovAuditGroup/Nexus_March25_MERGED/issues/10

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing documentation and improving the clarity of the `_uninstallValidator` and `uninstallModule` functions in the `ModuleManager` and `Nexus` contracts, respectively. It adds parameter descriptions and clarifies potential issues during uninstallation.

### Detailed summary
- Updated documentation for the `_uninstallValidator` function, adding parameter descriptions.
- Enhanced comments in the `uninstallModule` function to explain potential issues with malicious modules during uninstallation.
- Reformatted the `uninstallModule` function for improved readability by separating parameters and modifiers onto new lines.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->