### PR TITLE
Fix [L-10] Hook check bypass / remove double hooking check

### DIFF
--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -58,10 +58,6 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
     using ExcessivelySafeCall for address;
     using ECDSA for bytes32;
 
-    /// @dev The slot in the transient storage to store the hooking flag.
-    // keccak256("nexus.modulemanager.hooking")
-    bytes32 internal constant HOOKING_FLAG_TRANSIENT_STORAGE_SLOT = 0xe4a29a8042309a2ad08ae7c52d833b9d6166e6e098a4b7bfa75a8bad5472586d;
-
     /// @dev The default validator address.
     /// @notice To explicitly initialize the default validator, Nexus.execute(_DEFAULT_VALIDATOR.onInstall(...)) should be called.
     address internal immutable _DEFAULT_VALIDATOR;
@@ -84,16 +80,9 @@ abstract contract ModuleManager is Storage, EIP712, IModuleManagerEventsAndError
     /// @dev sender, msg.data and msg.value is passed to the hook to implement custom flows.
     modifier withHook() {
         address hook = _getHook();
-        bool hooking;
-        assembly {
-            hooking := tload(HOOKING_FLAG_TRANSIENT_STORAGE_SLOT)
-        }
-        if (hook == address(0) || hooking) {
+        if (hook == address(0)) {
             _;
         } else {
-            assembly {
-                tstore(HOOKING_FLAG_TRANSIENT_STORAGE_SLOT, 1)
-            }
             bytes memory hookData = IHook(hook).preCheck(msg.sender, msg.value, msg.data);
             _;
             IHook(hook).postCheck(hookData);

--- a/test/foundry/unit/concrete/modulemanager/TestModuleManager_FallbackHandler.t.sol
+++ b/test/foundry/unit/concrete/modulemanager/TestModuleManager_FallbackHandler.t.sol
@@ -406,49 +406,7 @@ contract TestModuleManager_FallbackHandler is TestModuleManagement_Base {
         emit PostCheckCalled();
         bytes memory result2 = IHandler(address(BOB_ACCOUNT)).returnBytes();
         assertEq(result2, expectedResult);
-    }
-
-    function test_No_Double_Hooking() public {
-        MockMultiModule multiModule = new MockMultiModule();
-
-        bytes memory customData = abi.encode(bytes5(abi.encodePacked(bytes4(0x0d50031f), CALLTYPE_SINGLE)));
-        bytes memory callData = abi.encodeWithSelector(
-            IModuleManager.installModule.selector,
-            MODULE_TYPE_FALLBACK,
-            address(multiModule),
-            customData
-        );
-
-        bytes memory callData2 = abi.encodeWithSelector(
-            IModuleManager.installModule.selector,
-            MODULE_TYPE_EXECUTOR,
-            address(multiModule),
-            ""
-        );
-
-        Execution[] memory executions = new Execution[](2);
-        executions[0] = Execution(address(BOB_ACCOUNT), 0, callData);
-        executions[1] = Execution(address(BOB_ACCOUNT), 0, callData2);
-        PackedUserOperation[] memory userOps = buildPackedUserOperation(BOB, BOB_ACCOUNT, EXECTYPE_DEFAULT, executions, address(VALIDATOR_MODULE), 0);
-        ENTRYPOINT.handleOps(userOps, payable(address(BOB.addr)));
-
-        assertEq(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_FALLBACK, address(multiModule), customData), true);
-        assertEq(BOB_ACCOUNT.isModuleInstalled(MODULE_TYPE_EXECUTOR, address(multiModule), ""), true);
-
-        Execution memory execution = Execution(address(counter), 0, abi.encodeWithSelector(Counter.incrementNumber.selector));
-
-        uint256 hookUsedBefore = HOOK_MODULE.getA();
-        assertEq(counter.getNumber(), 0);
-        
-        vm.startPrank(address(ENTRYPOINT));
-        vm.expectEmit(true, true, true, true, address(HOOK_MODULE));
-        emit PreCheckCalled();
-        ISomeFallbackFunction(address(BOB_ACCOUNT)).someFallbackFunction(execution);
-        vm.stopPrank();
-
-        assertEq(HOOK_MODULE.getA(), hookUsedBefore + 1);
-        assertEq(counter.getNumber(), 1);
-    }     
+    }   
 }
 
 interface ISomeFallbackFunction {


### PR DESCRIPTION
Fix https://github.com/PashovAuditGroup/Nexus_March25_MERGED/issues/11

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on simplifying the `withHook` modifier in the `ModuleManager` contract and removing a test function related to double hooking.

### Detailed summary
- Removed the `HOOKING_FLAG_TRANSIENT_STORAGE_SLOT` constant and related assembly code from the `withHook` modifier.
- Simplified the logic in the `withHook` modifier by eliminating the `hooking` variable check.
- Deleted the `test_No_Double_Hooking` function from the test file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->