### PR TITLE
Add [validators] to the `initNexusWithDefaultValidatorAndOtherModules` funciton

### DIFF
--- a/contracts/utils/NexusBootstrap.sol
+++ b/contracts/utils/NexusBootstrap.sol
@@ -113,9 +113,11 @@ contract NexusBootstrap is ModuleManager {
     /// @notice Initializes the Nexus account with the default validator and other modules.
     /// @dev Intended to be called by the Nexus with a delegatecall.
     /// @param defaultValidatorInitData The initialization data for the default validator module.
+    /// @param validators The configuration array for validator modules.
     /// @param executors The configuration array for executor modules.
     /// @param hook The configuration for the hook module.
     /// @param fallbacks The configuration array for fallback handler modules.
+    /// @param preValidationHooks The configuration array for pre-validation hooks.
     /// @param registryConfig The registry configuration.
     function initNexusWithDefaultValidatorAndOtherModules(
         bytes calldata defaultValidatorInitData,

--- a/contracts/utils/NexusBootstrap.sol
+++ b/contracts/utils/NexusBootstrap.sol
@@ -84,6 +84,7 @@ contract NexusBootstrap is ModuleManager {
     /// @param fallbacks The configuration array for fallback handler modules.
     function initNexusWithDefaultValidatorAndOtherModulesNoRegistry(
         bytes calldata defaultValidatorInitData,
+        BootstrapConfig[] calldata validators,
         BootstrapConfig[] calldata executors,
         BootstrapConfig calldata hook,
         BootstrapConfig[] calldata fallbacks,
@@ -100,6 +101,7 @@ contract NexusBootstrap is ModuleManager {
 
         _initNexusWithDefaultValidatorAndOtherModules(
             defaultValidatorInitData, 
+            validators,
             executors, 
             hook, 
             fallbacks, 
@@ -117,6 +119,7 @@ contract NexusBootstrap is ModuleManager {
     /// @param registryConfig The registry configuration.
     function initNexusWithDefaultValidatorAndOtherModules(
         bytes calldata defaultValidatorInitData,
+        BootstrapConfig[] calldata validators,
         BootstrapConfig[] calldata executors,
         BootstrapConfig calldata hook,
         BootstrapConfig[] calldata fallbacks,
@@ -127,7 +130,8 @@ contract NexusBootstrap is ModuleManager {
         payable
     {
         _initNexusWithDefaultValidatorAndOtherModules(
-            defaultValidatorInitData, 
+            defaultValidatorInitData,
+            validators,
             executors, 
             hook, 
             fallbacks, 
@@ -138,6 +142,7 @@ contract NexusBootstrap is ModuleManager {
 
     function _initNexusWithDefaultValidatorAndOtherModules(
         bytes calldata defaultValidatorInitData,
+        BootstrapConfig[] calldata validators,
         BootstrapConfig[] calldata executors,
         BootstrapConfig calldata hook,
         BootstrapConfig[] calldata fallbacks,
@@ -150,6 +155,12 @@ contract NexusBootstrap is ModuleManager {
         _configureRegistry(registryConfig.registry, registryConfig.attesters, registryConfig.threshold);
 
         IModule(_DEFAULT_VALIDATOR).onInstall(defaultValidatorInitData);
+
+        for (uint256 i; i < validators.length; i++) {
+            if (validators[i].module == address(0)) continue;
+            _installValidator(validators[i].module, validators[i].data);
+            emit ModuleInstalled(MODULE_TYPE_VALIDATOR, validators[i].module);
+        }
 
         for (uint256 i; i < executors.length; i++) {
             if (executors[i].module == address(0)) continue;
@@ -411,7 +422,7 @@ contract NexusBootstrap is ModuleManager {
     /// @dev EIP712 domain name and version.
     function _domainNameAndVersion() internal pure override returns (string memory name, string memory version) {
         name = "NexusBootstrap";
-        version = "1.2.0";
+        version = "1.2.1";
     }
 
     

--- a/contracts/utils/NexusBootstrap.sol
+++ b/contracts/utils/NexusBootstrap.sol
@@ -79,9 +79,11 @@ contract NexusBootstrap is ModuleManager {
     /// @notice Initializes the Nexus account with the default validator and other modules and no registry.
     /// @dev Intended to be called by the Nexus with a delegatecall.
     /// @param defaultValidatorInitData The initialization data for the default validator module.
+    /// @param validators The configuration array for validator modules. Should not contain the default validator.
     /// @param executors The configuration array for executor modules.
     /// @param hook The configuration for the hook module.
     /// @param fallbacks The configuration array for fallback handler modules.
+    /// @param preValidationHooks The configuration array for pre-validation hooks.
     function initNexusWithDefaultValidatorAndOtherModulesNoRegistry(
         bytes calldata defaultValidatorInitData,
         BootstrapConfig[] calldata validators,
@@ -113,7 +115,7 @@ contract NexusBootstrap is ModuleManager {
     /// @notice Initializes the Nexus account with the default validator and other modules.
     /// @dev Intended to be called by the Nexus with a delegatecall.
     /// @param defaultValidatorInitData The initialization data for the default validator module.
-    /// @param validators The configuration array for validator modules.
+    /// @param validators The configuration array for validator modules. Should not contain the default validator.
     /// @param executors The configuration array for executor modules.
     /// @param hook The configuration for the hook module.
     /// @param fallbacks The configuration array for fallback handler modules.
@@ -201,7 +203,7 @@ contract NexusBootstrap is ModuleManager {
 
     /// @notice Initializes the Nexus account with a single validator and no registry.
     /// @dev Intended to be called by the Nexus with a delegatecall.
-    /// @param validator The address of the validator module.
+    /// @param validator The address of the validator module. Should not be the default validator.
     /// @param data The initialization data for the validator module.
     function initNexusWithSingleValidatorNoRegistry(
         address validator,
@@ -220,7 +222,7 @@ contract NexusBootstrap is ModuleManager {
 
     /// @notice Initializes the Nexus account with a single validator.
     /// @dev Intended to be called by the Nexus with a delegatecall.
-    /// @param validator The address of the validator module.
+    /// @param validator The address of the validator module. Should not be the default validator.
     /// @param data The initialization data for the validator module.
     /// @param registryConfig The registry configuration.
     function initNexusWithSingleValidator(
@@ -253,10 +255,11 @@ contract NexusBootstrap is ModuleManager {
 
     /// @notice Initializes the Nexus account with multiple modules and no registry.
     /// @dev Intended to be called by the Nexus with a delegatecall.
-    /// @param validators The configuration array for validator modules.
+    /// @param validators The configuration array for validator modules. Should not contain the default validator.
     /// @param executors The configuration array for executor modules.
     /// @param hook The configuration for the hook module.
     /// @param fallbacks The configuration array for fallback handler modules.
+    /// @param preValidationHooks The configuration array for pre-validation hooks.
     function initNexusNoRegistry(
         BootstrapConfig[] calldata validators,
         BootstrapConfig[] calldata executors,
@@ -278,10 +281,11 @@ contract NexusBootstrap is ModuleManager {
 
     /// @notice Initializes the Nexus account with multiple modules.
     /// @dev Intended to be called by the Nexus with a delegatecall.
-    /// @param validators The configuration array for validator modules.
+    /// @param validators The configuration array for validator modules. Should not contain the default validator.
     /// @param executors The configuration array for executor modules.
     /// @param hook The configuration for the hook module.
     /// @param fallbacks The configuration array for fallback handler modules.
+    /// @param preValidationHooks The configuration array for pre-validation hooks.
     /// @param registryConfig The registry configuration.
     function initNexus(
         BootstrapConfig[] calldata validators,
@@ -361,7 +365,7 @@ contract NexusBootstrap is ModuleManager {
 
     /// @notice Initializes the Nexus account with a scoped set of modules and no registry.
     /// @dev Intended to be called by the Nexus with a delegatecall.
-    /// @param validators The configuration array for validator modules.
+    /// @param validators The configuration array for validator modules. Should not contain the default validator.
     /// @param hook The configuration for the hook module.
     function initNexusScopedNoRegistry(
         BootstrapConfig[] calldata validators,
@@ -380,7 +384,7 @@ contract NexusBootstrap is ModuleManager {
 
     /// @notice Initializes the Nexus account with a scoped set of modules.
     /// @dev Intended to be called by the Nexus with a delegatecall.
-    /// @param validators The configuration array for validator modules.
+    /// @param validators The configuration array for validator modules. Should not contain the default validator.
     /// @param hook The configuration for the hook module.
     /// @param registryConfig The registry configuration.
     function initNexusScoped(
@@ -396,7 +400,7 @@ contract NexusBootstrap is ModuleManager {
 
     /// @notice Initializes the Nexus account with a scoped set of modules.
     /// @dev Intended to be called by the Nexus with a delegatecall.
-    /// @param validators The configuration array for validator modules.
+    /// @param validators The configuration array for validator modules. Should not contain the default validator.
     /// @param hook The configuration for the hook module.
     function _initNexusScoped(
         BootstrapConfig[] calldata validators,


### PR DESCRIPTION
request from the SDK

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the documentation of the `NexusBootstrap` contract by adding details about the `validators` parameter across multiple functions. It also updates the version from `1.2.0` to `1.2.1`.

### Detailed summary
- Added `validators` parameter description to:
  - `initNexusWithDefaultValidatorAndOtherModulesNoRegistry`
  - `initNexusWithDefaultValidatorAndOtherModules`
  - `_initNexusWithDefaultValidatorAndOtherModules`
  - `initNexusWithSingleValidatorNoRegistry`
  - `initNexusWithSingleValidator`
  - `initNexusNoRegistry`
  - `initNexus`
  - `initNexusScopedNoRegistry`
  - `initNexusScoped`
  - `_initNexusScoped`
- Updated version from `1.2.0` to `1.2.1`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->