### PR TITLE
chore: fix branch matching in `ignoreBranches`

### DIFF
--- a/scripts/git-hooks/checkBranchNames.js
+++ b/scripts/git-hooks/checkBranchNames.js
@@ -2,7 +2,7 @@
 const execSync = require("child_process").execSync;
 const branchName = execSync("git branch --show-current").toString().trim();
 const pattern = /^(feat\/|fix\/|release\/|chore\/)/;
-const ignoreBranches = /^(main|dev)$/;
+const ignoreBranches = /^(main|dev)(\/|$)/;
 
 if (!ignoreBranches.test(branchName) && !pattern.test(branchName)) {
   console.error(


### PR DESCRIPTION
`dev/feature-123` wasn’t ignored due to exact match regex.
updated the pattern to handle nested branches.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the branch name validation logic in the `checkBranchNames.js` script to ensure that `main` and `dev` branches are correctly ignored in a more precise manner.

### Detailed summary
- Modified the `ignoreBranches` regex pattern from `/^(main|dev)$/` to `/^(main|dev)(\/|$)/` to allow for branch names like `main/feature` and `dev/bugfix` to be excluded from validation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->