### PR TITLE
fix: correct typos in NonceLib comment documentation

### DIFF
--- a/contracts/lib/NonceLib.sol
+++ b/contracts/lib/NonceLib.sol
@@ -18,7 +18,7 @@ library NonceLib {
         }
     }
 
-    /// @dev Detects if Validaton Mode is Module Enable Mode
+    /// @dev Detects if Validation Mode is Module Enable Mode
     /// @param nonce The nonce
     /// @return res boolean result, true if it is the Module Enable Mode
     function isModuleEnableMode(uint256 nonce) internal pure returns (bool res) {
@@ -38,7 +38,7 @@ library NonceLib {
         }
     }
 
-    /// @dev Detects if Validaton Mode is Prep Mode
+    /// @dev Detects if Validation Mode is Prep Mode
     /// @param nonce The nonce
     /// @return res boolean result, true if it is the Prep Mode
     function isPrepMode(uint256 nonce) internal pure returns (bool res) {
@@ -48,9 +48,9 @@ library NonceLib {
         }
     }
 
-    /// @dev Detects if Validaton Mode is Validate Mode
+    /// @dev Detects if Validation Mode is Validate Mode
     /// @param nonce The nonce
-    /// @return res boolean result, true if it is the Validate Mode
+    /// @return res boolean result, true if it is the Validation Mode
     function isValidateMode(uint256 nonce) internal pure returns (bool res) {
         assembly {
             let vmode := byte(3, nonce)


### PR DESCRIPTION


Fixes the misspelled word "Validaton" to "Validation" in three function comments within NonceLib.sol to improve code documentation quality and consistency.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting typos in the documentation comments of functions in the `NonceLib` library. The changes ensure that the term "Validation" is consistently spelled correctly.

### Detailed summary
- Changed "Validaton" to "Validation" in the documentation of `isModuleEnableMode`, `isPrepMode`, and `isValidateMode`.
- Updated the return description in `isValidateMode` to reflect "Validation Mode" instead of "Validate Mode".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->