### PR TITLE
docs: correct typo in deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Generate documentation from NatSpec comments.
 Nexus contracts are pre-deployed on most EVM chains.
 Please see the addresses [here](https://docs.biconomy.io/contractsAndAudits).
 
-If you need to deploy Nexus on your own chain or you want to deploy the contracts with different addresses, please see [this](https://github.com/bcnmy/nexus/tree/deploy-v1.0.1/scripts/bash-deploy) script. Or the same script on differnet deploy branches.
+If you need to deploy Nexus on your own chain or you want to deploy the contracts with different addresses, please see [this](https://github.com/bcnmy/nexus/tree/deploy-v1.0.1/scripts/bash-deploy) script. Or the same script on different deploy branches.
 
 ### 🎨 Lint Code
 


### PR DESCRIPTION
found and corrected a minor typo — "differnet" is now properly written as "different" in the deployment instructions.

keeping the docs accurate and professional.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting a typographical error in the `README.md` file regarding the word "differnet."

### Detailed summary
- Fixed the typo "differnet" to "different" in the deployment instructions section of the `README.md` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->