### PR TITLE
feat: 7702 relay init

### DIFF
--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -308,7 +308,7 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
         // account calls itself
         if (msg.sender != address(this)) {
             if (_amIERC7702()) {
-                // If this is a 7702 account, we allow passing signature with the initData
+                // If this is a 7702 account, we allow passing a user signature with the initData
                 // to initialize the account. This allows 7702 accounts to be initialized
                 // by a relayer.
                 bytes calldata signature = initData[0:65];

--- a/contracts/Nexus.sol
+++ b/contracts/Nexus.sol
@@ -50,6 +50,7 @@ import { Initializable } from "./lib/Initializable.sol";
 import { EmergencyUninstall } from "./types/DataTypes.sol";
 import { LibPREP } from "lib-prep/LibPREP.sol";
 import { ComposableExecutionBase, ComposableExecution } from "composability/ComposableExecutionBase.sol";
+import { ECDSA } from "solady/utils/ECDSA.sol";
 
 /// @title Nexus - Smart Account
 /// @notice This contract integrates various functionalities to handle modular smart accounts compliant with ERC-7579 and ERC-4337 standards.
@@ -75,13 +76,7 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
     event EmergencyHookUninstallRequestReset(address hook, uint256 timestamp);
 
     /// @notice Initializes the smart account with the specified entry point.
-    constructor(
-        address anEntryPoint,
-        address defaultValidator,
-        bytes memory initData
-    )
-        ModuleManager(defaultValidator, initData)
-    {
+    constructor(address anEntryPoint, address defaultValidator, bytes memory initData) ModuleManager(defaultValidator, initData) {
         require(address(anEntryPoint) != address(0), EntryPointCanNotBeZero());
         _ENTRYPOINT = anEntryPoint;
     }
@@ -117,10 +112,10 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
     {
         address validator;
         PackedUserOperation memory userOp = op;
-    
+
         if (op.nonce.isValidateMode()) {
             // do nothing special. This is introduced
-            // to quickly identify the most commonly used 
+            // to quickly identify the most commonly used
             // mode which is validate mode
             // and avoid checking two above conditions
         } else if (op.nonce.isModuleEnableMode()) {
@@ -250,16 +245,7 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
     /// @param module The address of the module to uninstall.
     /// @param deInitData De-initialization data for the module.
     /// @dev Ensures that the operation is authorized and valid before proceeding with the uninstallation.
-    function uninstallModule(
-        uint256 moduleTypeId,
-        address module,
-        bytes calldata deInitData
-    ) 
-        external 
-        payable
-        onlyEntryPointOrSelf
-        withHook 
-    {
+    function uninstallModule(uint256 moduleTypeId, address module, bytes calldata deInitData) external payable onlyEntryPointOrSelf withHook {
         require(_isModuleInstalled(moduleTypeId, module, deInitData), ModuleNotInstalled(moduleTypeId, module));
 
         if (moduleTypeId == MODULE_TYPE_VALIDATOR) {
@@ -321,7 +307,30 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
         // Protect this function to only be callable when used with the proxy factory or when
         // account calls itself
         if (msg.sender != address(this)) {
-            Initializable.requireInitializable();
+            if (_amIERC7702()) {
+                // If this is a 7702 account, we allow passing signature with the initData
+                // to initialize the account. This allows 7702 accounts to be initialized
+                // by a relayer.
+                bytes calldata signature = initData[0:65];
+                // Get the nonce from the initData
+                uint256 nonce;
+                assembly {
+                    nonce := calldataload(add(initData.offset, 0x41))
+                }
+                AccountStorage storage $accountStorage = _getAccountStorage();
+                // Make sure the nonce is valid
+                require(!$accountStorage.nonces[nonce], InvalidNonce());
+                // Mark nonce as used
+                $accountStorage.nonces[nonce] = true;
+                // Remove the signature and nonce from the initData
+                initData = initData[97:];
+                // Calculate the hash of the initData and nonce
+                bytes32 initDataHash = keccak256(abi.encode(keccak256(initData), nonce));
+                // Check if the signature is valid
+                require(ECDSA.recover(initDataHash, signature) == address(this), InvalidSignature());
+            } else {
+                Initializable.requireInitializable();
+            }
         }
         _initializeAccount(initData);
     }
@@ -340,10 +349,10 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
             bootstrapCall.length := calldataload(u)
         }
 
-        (bool success, ) = bootstrap.delegatecall(bootstrapCall);
+        (bool success,) = bootstrap.delegatecall(bootstrapCall);
 
         require(success, NexusInitializationFailed());
-        if(!_amIERC7702()) {
+        if (!_amIERC7702()) {
             require(isInitialized(), AccountNotInitialized());
         }
     }
@@ -374,7 +383,7 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
         }
         // else proceed with normal signature verification
         // First 20 bytes of data will be validator address and rest of the bytes is complete signature.
-        address validator = _handleValidator(address(bytes20(signature[0:20]))); 
+        address validator = _handleValidator(address(bytes20(signature[0:20])));
         bytes memory signature_;
         (hash, signature_) = _withPreValidationHook(hash, signature[20:]);
         try IValidator(validator).isValidSignatureWithSender(msg.sender, hash, signature_) returns (bytes4 res) {
@@ -402,14 +411,11 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
     /// @param moduleTypeId The identifier of the module type to check.
     /// @return True if the module type is supported, false otherwise.
     function supportsModule(uint256 moduleTypeId) external view virtual returns (bool) {
-        if (moduleTypeId == MODULE_TYPE_VALIDATOR ||
-            moduleTypeId == MODULE_TYPE_EXECUTOR ||
-            moduleTypeId == MODULE_TYPE_FALLBACK ||
-            moduleTypeId == MODULE_TYPE_HOOK ||
-            moduleTypeId == MODULE_TYPE_PREVALIDATION_HOOK_ERC1271 ||
-            moduleTypeId == MODULE_TYPE_PREVALIDATION_HOOK_ERC4337 ||
-            moduleTypeId == MODULE_TYPE_MULTI)
-        {
+        if (
+            moduleTypeId == MODULE_TYPE_VALIDATOR || moduleTypeId == MODULE_TYPE_EXECUTOR || moduleTypeId == MODULE_TYPE_FALLBACK
+                || moduleTypeId == MODULE_TYPE_HOOK || moduleTypeId == MODULE_TYPE_PREVALIDATION_HOOK_ERC1271
+                || moduleTypeId == MODULE_TYPE_PREVALIDATION_HOOK_ERC4337 || moduleTypeId == MODULE_TYPE_MULTI
+        ) {
             return true;
         }
         return false;
@@ -440,10 +446,7 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
     /// @dev In case default validator is initialized, two other SLOADS from _areSentinelListsInitialized() are not checked,
     /// this method should not introduce huge gas overhead.
     function isInitialized() public view returns (bool) {
-        return (
-            IValidator(_DEFAULT_VALIDATOR).isInitialized(address(this)) ||
-            _areSentinelListsInitialized()
-        );
+        return (IValidator(_DEFAULT_VALIDATOR).isInitialized(address(this)) || _areSentinelListsInitialized());
     }
 
     /// Returns the account's implementation ID.
@@ -508,7 +511,7 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
     /// This is part of the UUPS (Universal Upgradeable Proxy Standard) pattern.
     /// @param newImplementation The address of the new implementation to upgrade to.
     function _authorizeUpgrade(address newImplementation) internal virtual override(UUPSUpgradeable) onlyEntryPointOrSelf {
-        if(_amIERC7702()) {
+        if (_amIERC7702()) {
             revert ERC7702AccountCannotBeUpgradedThisWay();
         }
     }
@@ -525,7 +528,7 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
                 mstore(0x0, 0xaed59595) // NotInitializable()
                 revert(0x1c, 0x04)
             }
-            
+
             saltAndDelegation := calldataload(data.offset)
 
             // initData
@@ -540,7 +543,7 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
             cleanedSignature.offset := add(u, 0x20)
             cleanedSignature.length := calldataload(u)
         }
-        
+
         // check r is valid
         bytes32 r = LibPREP.rPREP(address(this), keccak256(initData), saltAndDelegation);
         if (r == bytes32(0)) {
@@ -551,23 +554,24 @@ contract Nexus is INexus, BaseAccount, ExecutionHelper, ModuleManager, UUPSUpgra
 
     // checks if there's at least one validator initialized
     function _checkInitializedValidators() internal view {
-        if(!_amIERC7702() && !IValidator(_DEFAULT_VALIDATOR).isInitialized(address(this))) {
+        if (!_amIERC7702() && !IValidator(_DEFAULT_VALIDATOR).isInitialized(address(this))) {
             unchecked {
                 SentinelListLib.SentinelList storage validators = _getAccountStorage().validators;
                 address next = validators.entries[SENTINEL];
                 while (next != ZERO_ADDRESS && next != SENTINEL) {
-                    if(IValidator(next).isInitialized(address(this))) {
+                    if (IValidator(next).isInitialized(address(this))) {
                         break;
                     }
                     next = validators.getNext(next);
                 }
-                if(next == SENTINEL) { //went through all validators and none was initialized
+                if (next == SENTINEL) {
+                    //went through all validators and none was initialized
                     revert CanNotRemoveLastValidator();
                 }
             }
         }
     }
-    
+
     /// @dev EIP712 domain name and version.
     function _domainNameAndVersion() internal pure override returns (string memory name, string memory version) {
         name = "Nexus";

--- a/contracts/interfaces/INexusEventsAndErrors.sol
+++ b/contracts/interfaces/INexusEventsAndErrors.sol
@@ -65,4 +65,7 @@ interface INexusEventsAndErrors {
 
     /// @notice Error thrown when the account is not initialized but expected to be.
     error AccountNotInitialized();
+
+    /// @notice Error thrown when the provided signature is invalid.
+    error InvalidSignature();
 }

--- a/contracts/interfaces/base/IStorage.sol
+++ b/contracts/interfaces/base/IStorage.sol
@@ -49,6 +49,8 @@ interface IStorage {
         mapping(uint256 => bool) nonces;
         ///< ERC-7484 registry
         address registry;
+        ///< Mapping of used 7702 init hashes for replay protection.
+        mapping(bytes32 => bool) erc7702InitHashes;
     }
 
     /// @notice Defines a fallback handler with an associated handler address and a call type.

--- a/test/foundry/utils/EventsAndErrors.sol
+++ b/test/foundry/utils/EventsAndErrors.sol
@@ -47,7 +47,7 @@ contract EventsAndErrors {
     error CallToDeployWithFactoryFailed();
     error NexusInitializationFailed();
     error InvalidThreshold(uint8 providedThreshold, uint256 attestersCount);
-    error InvalidNonce();
+    error AccountAlreadyInitialized();
 
     // ==========================
     // Operation Errors

--- a/test/foundry/utils/EventsAndErrors.sol
+++ b/test/foundry/utils/EventsAndErrors.sol
@@ -47,6 +47,7 @@ contract EventsAndErrors {
     error CallToDeployWithFactoryFailed();
     error NexusInitializationFailed();
     error InvalidThreshold(uint8 providedThreshold, uint256 attestersCount);
+    error InvalidNonce();
 
     // ==========================
     // Operation Errors

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@ERC4337/account-abstraction-v0.6@github:eth-infinitism/account-abstraction#v0.6.0":
+"@ERC4337/account-abstraction-v0.6@github:eth-infinitism/account-abstraction#v0.6.0", "account-abstraction-v0.6@github:eth-infinitism/account-abstraction#v0.6.0":
   version "0.6.0"
   resolved "https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/abff2aca61a8f0934e533d0d352978055fddbd96"
   dependencies:
@@ -21,7 +21,7 @@
     table "^6.8.0"
     typescript "^4.3.5"
 
-"@ERC4337/account-abstraction@github:kopy-kat/account-abstraction#develop":
+"@ERC4337/account-abstraction@github:kopy-kat/account-abstraction#develop", "account-abstraction@github:kopy-kat/account-abstraction#develop":
   version "0.7.0"
   resolved "https://codeload.github.com/kopy-kat/account-abstraction/tar.gz/c5887153fbfe3ed09b2637cac39873f96d676f38"
   dependencies:
@@ -60,9 +60,9 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz#24b64e2c3ec7cd3b3c547729b8d16871f22cbdc7"
   integrity sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==
 
-"@biconomy/composability@github:bcnmy/composability":
+"@biconomy/composability@github:bcnmy/composability#v1.0.0":
   version "0.0.1"
-  resolved "https://codeload.github.com/bcnmy/composability/tar.gz/c4f072e19bef0e34070cc8a1ece14e54e8634d32"
+  resolved "https://codeload.github.com/bcnmy/composability/tar.gz/9e090c24b195822f668f96cb4ff518a9b7ff712d"
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
@@ -857,9 +857,6 @@
   resolved "https://codeload.github.com/rhinestonewtf/safe7579/tar.gz/33f110f08ed5fcab75c29d7cfb93f7f3e4da76a7"
   dependencies:
     "@ERC4337/account-abstraction" "github:kopy-kat/account-abstraction#develop"
-    "@ERC4337/account-abstraction-v0.6" "github:eth-infinitism/account-abstraction#v0.6.0"
-    "@rhinestone/checknsignatures" "github:rhinestonewtf/checknsignatures"
-    "@rhinestone/erc4337-validation" "0.0.1-alpha.2"
     "@rhinestone/module-bases" "github:rhinestonewtf/module-bases"
     "@rhinestone/sentinellist" "github:rhinestonewtf/sentinellist"
     "@safe-global/safe-contracts" "^1.4.1"
@@ -1232,48 +1229,9 @@ abbrev@1.0.x:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
   integrity sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q==
 
-"account-abstraction-v0.6@github:eth-infinitism/account-abstraction#v0.6.0":
-  version "0.6.0"
-  resolved "https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/abff2aca61a8f0934e533d0d352978055fddbd96"
-  dependencies:
-    "@gnosis.pm/safe-contracts" "^1.3.0"
-    "@nomiclabs/hardhat-etherscan" "^2.1.6"
-    "@openzeppelin/contracts" "^4.2.0"
-    "@thehubbleproject/bls" "^0.5.1"
-    "@typechain/hardhat" "^2.3.0"
-    "@types/mocha" "^9.0.0"
-    ethereumjs-util "^7.1.0"
-    ethereumjs-wallet "^1.0.1"
-    hardhat-deploy "^0.11.23"
-    hardhat-deploy-ethers "^0.3.0-beta.11"
-    solidity-coverage "^0.8.2"
-    source-map-support "^0.5.19"
-    table "^6.8.0"
-    typescript "^4.3.5"
-
 "account-abstraction@github:eth-infinitism/account-abstraction#develop":
   version "0.7.0"
   resolved "https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/6f02f5a28a20e804d0410b4b5b570dd4b076dcf9"
-  dependencies:
-    "@nomiclabs/hardhat-etherscan" "^2.1.6"
-    "@openzeppelin/contracts" "^5.0.0"
-    "@thehubbleproject/bls" "^0.5.1"
-    "@typechain/hardhat" "^2.3.0"
-    "@types/debug" "^4.1.12"
-    "@types/mocha" "^9.0.0"
-    debug "^4.3.4"
-    ethereumjs-util "^7.1.0"
-    ethereumjs-wallet "^1.0.1"
-    hardhat-deploy "^0.11.23"
-    hardhat-deploy-ethers "^0.3.0-beta.11"
-    solidity-coverage "^0.8.4"
-    source-map-support "^0.5.19"
-    table "^6.8.0"
-    typescript "^4.3.5"
-
-"account-abstraction@github:kopy-kat/account-abstraction#develop":
-  version "0.7.0"
-  resolved "https://codeload.github.com/kopy-kat/account-abstraction/tar.gz/c5887153fbfe3ed09b2637cac39873f96d676f38"
   dependencies:
     "@nomiclabs/hardhat-etherscan" "^2.1.6"
     "@openzeppelin/contracts" "^5.0.0"


### PR DESCRIPTION
- allows initializing a 7702 account when `msg.sender != address(this)` which is a valid scenario when a relayer is used to create an account