### PR TITLE
pragma solidity, gte instead of eq

### DIFF
--- a/contracts/lib/NonceLib.sol
+++ b/contracts/lib/NonceLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.27;
+pragma solidity ^0.8.27;
 
 import { MODE_MODULE_ENABLE, MODE_PREP, MODE_VALIDATION } from "../types/Constants.sol";
 

--- a/contracts/lib/local/LocalCallDataParserLib.sol
+++ b/contracts/lib/local/LocalCallDataParserLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.27;
+pragma solidity ^0.8.27;
 
 library LocalCallDataParserLib {
     /// @dev Parses the `userOp.signature` to extract the module type, module initialization data,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the Solidity version pragma in two files to allow for compatibility with any version starting from `0.8.27`, enhancing flexibility for future updates.

### Detailed summary
- Updated `pragma solidity` in `contracts/lib/NonceLib.sol` from `0.8.27` to `^0.8.27`.
- Updated `pragma solidity` in `contracts/lib/local/LocalCallDataParserLib.sol` from `0.8.27` to `^0.8.27`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->