### PR TITLE
build: update checkout action to v5

### DIFF
--- a/.github/workflows/automation_workflow.yml
+++ b/.github/workflows/automation_workflow.yml
@@ -10,7 +10,7 @@ jobs:
   check-files:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.6
+      - uses: actions/checkout@v5.1.6
 
       - name: Check package.json
         uses: tj-actions/changed-files@v44.5.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       cache-key: ${{ steps.cache-keys.outputs.cache-key }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.6
+        uses: actions/checkout@v5.1.6
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -38,7 +38,7 @@ jobs:
     needs: setup
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.6
+        uses: actions/checkout@v5.1.6
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1.2.0
@@ -70,7 +70,7 @@ jobs:
     needs: setup
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.6
+        uses: actions/checkout@v5.1.6
 
       - name: Cache node modules
         uses: actions/cache@v4
@@ -100,7 +100,7 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.6
+      - uses: actions/checkout@v5.1.6
 
       - name: Cache node modules
         uses: actions/cache@v4
@@ -150,7 +150,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/foundry-gas-diff.yml
+++ b/.github/workflows/foundry-gas-diff.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
-      - uses: actions/checkout@v4.1.6
+      - uses: actions/checkout@v5.1.6
         with:
           submodules: recursive
       


### PR DESCRIPTION
GitHub-hosted runners now use Node 24, so actions/checkout@v5 is required. Minimum runner version v2.327.1. Workflows only updated—no functional changes.

See: https://github.com/actions/checkout/releases/tag/v5.0.0

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of the `actions/checkout` GitHub Action from `v4.1.6` to `v5.1.6` across multiple workflow files to leverage improvements and bug fixes in the latest version.

### Detailed summary
- Updated `actions/checkout` from `v4.1.6` to `v5.1.6` in:
  - `.github/workflows/foundry-gas-diff.yml`
  - `.github/workflows/automation_workflow.yml`
  - `.github/workflows/ci.yml`
  - Multiple steps in `.github/workflows/ci.yml` (repeated updates)
  - `.github/workflows/ci.yml` (additional updates in jobs)

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->